### PR TITLE
Refactor: Token 응답 JSON으로 변경

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/AuthController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/AuthController.java
@@ -64,16 +64,6 @@ public class AuthController {
     }
 
     private ResponseEntity<?> createTokenRes(TokenDto tokenDto) {
-        Map<String, Object> responseData = new HashMap<>();
-        responseData.put("accessToken", tokenDto.accessToken());
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE,
-                        CookieUtil.createCookie(
-                                REFRESH_TOKEN_KEY,
-                                tokenDto.refreshToken(),
-                                Duration.ofDays(7).toSeconds()
-                        ).toString())
-                .body(SuccessResponse.from(responseData));
+        return ResponseEntity.ok(SuccessResponse.from(tokenDto));
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/OAuthController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/OAuthController.java
@@ -46,20 +46,6 @@ public class OAuthController {
     }
 
     private ResponseEntity<?> createTokenRes(OAuthTokenDto oAuthTokenDto) {
-        Map<String, Object> responseData = new HashMap<>();
-
-        TokenDto tokenDto = oAuthTokenDto.tokenDto();
-
-        responseData.put("accessToken", tokenDto.accessToken());
-        responseData.put("isSignUp", oAuthTokenDto.isSignUp());
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE,
-                        CookieUtil.createCookie(
-                                REFRESH_TOKEN_KEY,
-                                tokenDto.refreshToken(),
-                                Duration.ofDays(7).toSeconds()
-                        ).toString())
-                .body(SuccessResponse.from(responseData));
+        return ResponseEntity.ok(SuccessResponse.from(oAuthTokenDto));
     }
 }


### PR DESCRIPTION
## 배경
앱의 경우 웹과 달리 쿠키를 통한 전달 x.
RefreshToken의 전달을 JSON으로 변경이 필요.

## 작업 사항
- Token 응답 쿠키에서 JSON으로 변경 (e805cac4f362229a7958e8baaf9d3cfba5b948e8)

## 기타
- Admin의 경우 웹으로 진행하기에, Admin은 RefreshToken을 쿠키로 전달 예정