### PR TITLE
Feature: 사용자 조회 시, 구독 소식 및 키워드 조회 추가

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/dto/UserRes.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/dto/UserRes.java
@@ -1,14 +1,38 @@
 package kr.co.yournews.apis.user.dto;
 
+import kr.co.yournews.domain.news.dto.SubNewsQueryDto;
+import kr.co.yournews.domain.news.type.KeywordType;
 import kr.co.yournews.domain.user.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public record UserRes(
         Long id,
         String username,
         String nickname,
-        String email
+        String email,
+        List<String> subscriptions,
+        List<KeywordType> keywords
 ) {
-    public static UserRes from(User user) {
-        return new UserRes(user.getId(), user.getUsername(), user.getNickname(), user.getEmail());
+    public static UserRes from(User user, List<SubNewsQueryDto> subNewsList) {
+        List<String> newsNames = new ArrayList<>();
+        List<KeywordType> keywords = new ArrayList<>();
+
+        for (SubNewsQueryDto dto : subNewsList) {
+            newsNames.add(dto.newsName());
+            if (dto.keywordTypes() != null) {
+                keywords.addAll(dto.keywordTypes());
+            }
+        }
+
+        return new UserRes(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                newsNames,
+                keywords
+        );
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/UserQueryService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/UserQueryService.java
@@ -2,6 +2,8 @@ package kr.co.yournews.apis.user.service;
 
 import kr.co.yournews.apis.user.dto.UserRes;
 import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.domain.news.dto.SubNewsQueryDto;
+import kr.co.yournews.domain.news.service.SubNewsService;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
 import kr.co.yournews.domain.user.service.UserService;
@@ -9,10 +11,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserQueryService {
     private final UserService userService;
+    private final SubNewsService subNewsService;
 
     /**
      * 사용자의 정보를 조회하는 메서드
@@ -25,6 +30,9 @@ public class UserQueryService {
         User user = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
-        return UserRes.from(user);
+        List<SubNewsQueryDto> subNewsDtos =
+                subNewsService.readSubNewsWithKeywordsByUserId(userId);
+
+        return UserRes.from(user, subNewsDtos);
     }
 }

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/controller/SecuredUserControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/controller/SecuredUserControllerTest.java
@@ -25,6 +25,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.List;
+
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -86,7 +88,7 @@ public class SecuredUserControllerTest {
         @DisplayName("사용자 정보 조회 성공")
         void getUserInfoSuccess() throws Exception {
             // given
-            UserRes userRes = new UserRes(userId, "test", "테스터", "test@gmail.com");
+            UserRes userRes = new UserRes(userId, "test", "테스터", "test@gmail.com", List.of(), List.of());
 
             given(userQueryService.getUserInfoById(userId)).willReturn(userRes);
 

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/UserQueryServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/UserQueryServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.yournews.apis.user.service;
 
 import kr.co.yournews.apis.user.dto.UserRes;
 import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.domain.news.service.SubNewsService;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
 import kr.co.yournews.domain.user.service.UserService;
@@ -24,6 +25,9 @@ public class UserQueryServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private SubNewsService subNewsService;
 
     @InjectMocks
     private UserQueryService userQueryService;

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/news/dto/SubNewsQueryDto.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/news/dto/SubNewsQueryDto.java
@@ -1,0 +1,11 @@
+package kr.co.yournews.domain.news.dto;
+
+import kr.co.yournews.domain.news.type.KeywordType;
+
+import java.util.List;
+
+public record SubNewsQueryDto(
+        String newsName,
+        List<KeywordType> keywordTypes
+) {
+}

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/news/repository/subnews/CustomSubNewsRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/news/repository/subnews/CustomSubNewsRepository.java
@@ -1,9 +1,11 @@
 package kr.co.yournews.domain.news.repository.subnews;
 
+import kr.co.yournews.domain.news.dto.SubNewsQueryDto;
 import kr.co.yournews.domain.news.dto.UserKeywordDto;
 
 import java.util.List;
 
 public interface CustomSubNewsRepository {
     List<UserKeywordDto> findUserKeywordsByUserIds(List<Long> userIds);
+    List<SubNewsQueryDto> findSubNewsWithKeywordsByUserId(Long userId);
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/news/repository/subnews/CustomSubNewsRepositoryImpl.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/news/repository/subnews/CustomSubNewsRepositoryImpl.java
@@ -1,13 +1,19 @@
 package kr.co.yournews.domain.news.repository.subnews;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yournews.domain.news.dto.SubNewsQueryDto;
 import kr.co.yournews.domain.news.dto.UserKeywordDto;
 import kr.co.yournews.domain.news.entity.QKeyword;
 import kr.co.yournews.domain.news.entity.QSubNews;
+import kr.co.yournews.domain.news.type.KeywordType;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class CustomSubNewsRepositoryImpl implements CustomSubNewsRepository {
@@ -28,5 +34,30 @@ public class CustomSubNewsRepositoryImpl implements CustomSubNewsRepository {
                 .join(keyword).on(keyword.subNews.id.eq(subNews.id))
                 .where(subNews.user.id.in(userIds))
                 .fetch();
+    }
+
+    @Override
+    public List<SubNewsQueryDto> findSubNewsWithKeywordsByUserId(Long userId) {
+        List<Tuple> tuples = jpaQueryFactory
+                .select(subNews.newsName, keyword.keywordType)
+                .from(subNews)
+                .leftJoin(keyword).on(keyword.subNews.eq(subNews))
+                .where(subNews.user.id.eq(userId))
+                .fetch();
+
+        Map<String, List<KeywordType>> grouped = new LinkedHashMap<>();
+        for (Tuple t : tuples) {
+            String newsName = t.get(subNews.newsName);
+            KeywordType keywordType = t.get(keyword.keywordType);
+            grouped.computeIfAbsent(newsName, k -> new ArrayList<>());
+
+            if (keywordType != null) {
+                grouped.get(newsName).add(keywordType);
+            }
+        }
+
+        return grouped.entrySet().stream()
+                .map(e -> new SubNewsQueryDto(e.getKey(), e.getValue()))
+                .toList();
     }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/news/service/SubNewsService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/news/service/SubNewsService.java
@@ -1,5 +1,6 @@
 package kr.co.yournews.domain.news.service;
 
+import kr.co.yournews.domain.news.dto.SubNewsQueryDto;
 import kr.co.yournews.domain.news.dto.UserKeywordDto;
 import kr.co.yournews.domain.news.entity.SubNews;
 import kr.co.yournews.domain.news.repository.subnews.SubNewsRepository;
@@ -27,6 +28,10 @@ public class SubNewsService {
 
     public List<UserKeywordDto> readUserKeywordsByUserIds(List<Long> userIds) {
         return subNewsRepository.findUserKeywordsByUserIds(userIds);
+    }
+
+    public List<SubNewsQueryDto> readSubNewsWithKeywordsByUserId(Long userId) {
+        return subNewsRepository.findSubNewsWithKeywordsByUserId(userId);
     }
 
     public void deleteAllByUserId(Long userId) {

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/CustomUserRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/CustomUserRepository.java
@@ -1,0 +1,7 @@
+package kr.co.yournews.domain.user.repository;
+
+import java.util.List;
+
+public interface CustomUserRepository {
+    List<Long> findUserIdsByNewsNameAndSubStatusTrue(String newsName);
+}

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/CustomUserRepositoryImpl.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/CustomUserRepositoryImpl.java
@@ -1,0 +1,29 @@
+package kr.co.yournews.domain.user.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.yournews.domain.news.entity.QSubNews;
+import kr.co.yournews.domain.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserRepositoryImpl implements CustomUserRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QUser user = QUser.user;
+    private final QSubNews subNews = QSubNews.subNews;
+
+    @Override
+    public List<Long> findUserIdsByNewsNameAndSubStatusTrue(String newsName) {
+        return jpaQueryFactory
+                .select(user.id)
+                .from(user)
+                .join(subNews).on(subNews.user.id.eq(user.id))
+                .where(
+                        user.subStatus.isTrue(),
+                        subNews.newsName.eq(newsName)
+                )
+                .fetch();
+    }
+}

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/UserRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/UserRepository.java
@@ -10,22 +10,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
     boolean existsByNickname(String nickname);
     boolean existsByUsernameAndEmail(String username, String email);
-
-    @Query("""
-                SELECT u.id
-                FROM user u
-                JOIN sub_news sn ON u.id = sn.user.id
-                WHERE u.subStatus = true
-                  AND sn.newsName = :newsName
-            """)
-    List<Long> findUserIdsByNewsNameAndSubStatusTrue(@Param("newsName") String newsName);
 
     @Query(value = "SELECT * FROM user WHERE username = :username", nativeQuery = true)
     Optional<User> findByUsernameIncludeDeleted(@Param("username") String username);


### PR DESCRIPTION
## 배경
사용자 정보 조회 시, 구독한 소식 및 키워드 제공이 필요

## 작업 사항
- 구독 소식 및 키워드 조회 로직 구현 (eba0307a5d57833e318849ea8302e5fdd81fb282)
- 사용자 정보 로직에 구독 소식 및 키워드 추가 (653a3e602c497e63bae0a7b013040088c8e88ece)