### PR TITLE
Refactor: 로그아웃 및 FCM 토큰 관리 등 사용자 로직 리팩토링

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/AuthController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/AuthController.java
@@ -2,7 +2,9 @@ package kr.co.yournews.apis.auth.controller;
 
 import jakarta.validation.Valid;
 import kr.co.yournews.apis.auth.dto.RestoreUserDto;
+import kr.co.yournews.apis.auth.dto.SignOutDto;
 import kr.co.yournews.apis.auth.service.AuthCommandService;
+import kr.co.yournews.auth.authentication.CustomUserDetails;
 import kr.co.yournews.auth.dto.SignInDto;
 import kr.co.yournews.auth.dto.SignUpDto;
 import kr.co.yournews.auth.dto.TokenDto;
@@ -11,6 +13,7 @@ import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.common.response.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -40,9 +43,12 @@ public class AuthController {
 
     @PostMapping("/sign-out")
     public ResponseEntity<?> signOut(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestHeader("Authorization") String accessToken,
-            @RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken) {
-        authCommandService.signOut(accessToken, refreshToken);
+            @RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken,
+            @RequestBody SignOutDto signOutDto) {
+
+        authCommandService.signOut(accessToken, refreshToken, userDetails.getUserId(), signOutDto);
 
         return ResponseEntity.ok(SuccessResponse.ok());
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/dto/SignOutDto.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/dto/SignOutDto.java
@@ -1,0 +1,6 @@
+package kr.co.yournews.apis.auth.dto;
+
+public record SignOutDto(
+        String deviceInfo
+) {
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/AuthCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/AuthCommandService.java
@@ -1,8 +1,10 @@
 package kr.co.yournews.apis.auth.service;
 
 import kr.co.yournews.apis.auth.dto.RestoreUserDto;
+import kr.co.yournews.apis.auth.dto.SignOutDto;
 import kr.co.yournews.apis.auth.service.mail.AuthCodeService;
 import kr.co.yournews.apis.news.service.SubNewsCommandService;
+import kr.co.yournews.apis.user.service.FcmTokenCommandService;
 import kr.co.yournews.auth.dto.SignInDto;
 import kr.co.yournews.auth.dto.SignUpDto;
 import kr.co.yournews.auth.dto.TokenDto;
@@ -26,6 +28,7 @@ public class AuthCommandService {
     private final JwtHelper jwtHelper;
     private final AuthCodeService authCodeService;
     private final SubNewsCommandService subNewsCommandService;
+    private final FcmTokenCommandService fcmTokenCommandService;
 
     /**
      * dto를 통해 비밀번호 인코딩 후, 회원가입 진행 메서드.
@@ -113,7 +116,13 @@ public class AuthCommandService {
      * @param accessTokenInHeader : 헤더에 있는 accessToken
      * @param refreshToken        : refresh token
      */
-    public void signOut(String accessTokenInHeader, String refreshToken) {
+    public void signOut(
+            String accessTokenInHeader,
+            String refreshToken,
+            Long userId,
+            SignOutDto signOutDto
+    ) {
+        fcmTokenCommandService.deleteTokenByUserAndDevice(userId, signOutDto.deviceInfo());
         String accessToken = accessTokenInHeader.substring(TOKEN_TYPE.length()).trim();
         jwtHelper.removeToken(accessToken, refreshToken);
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/mail/controller/MailController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/mail/controller/MailController.java
@@ -1,8 +1,8 @@
-package kr.co.yournews.apis.auth.mail.controller;
+package kr.co.yournews.apis.mail.controller;
 
 import jakarta.validation.Valid;
-import kr.co.yournews.apis.auth.mail.dto.InquiryMailReq;
-import kr.co.yournews.apis.auth.mail.service.InquiryMailer;
+import kr.co.yournews.apis.mail.dto.InquiryMailReq;
+import kr.co.yournews.apis.mail.service.InquiryMailer;
 import kr.co.yournews.common.response.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/mail/dto/InquiryMailReq.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/mail/dto/InquiryMailReq.java
@@ -1,4 +1,4 @@
-package kr.co.yournews.apis.auth.mail.dto;
+package kr.co.yournews.apis.mail.dto;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/mail/service/InquiryMailer.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/mail/service/InquiryMailer.java
@@ -1,6 +1,6 @@
-package kr.co.yournews.apis.auth.mail.service;
+package kr.co.yournews.apis.mail.service;
 
-import kr.co.yournews.apis.auth.mail.dto.InquiryMailReq;
+import kr.co.yournews.apis.mail.dto.InquiryMailReq;
 import kr.co.yournews.infra.mail.MailSenderAdapter;
 import kr.co.yournews.infra.mail.strategy.MailStrategyFactory;
 import kr.co.yournews.infra.mail.type.MailType;

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/controller/FcmTokenController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/controller/FcmTokenController.java
@@ -30,7 +30,7 @@ public class FcmTokenController {
     @DeleteMapping
     public ResponseEntity<?> deleteToken(@AuthenticationPrincipal CustomUserDetails userDetails,
                                          @RequestBody FcmTokenReq.Delete deleteDto) {
-        fcmTokenCommandService.deleteTokenByUserAndDevice(userDetails.getUserId(), deleteDto);
+        fcmTokenCommandService.deleteTokenByUserAndDevice(userDetails.getUserId(), deleteDto.deviceInfo());
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/dto/UserRes.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/dto/UserRes.java
@@ -15,7 +15,8 @@ public record UserRes(
         List<String> subscriptions,
         List<String> keywords,
         boolean subStatus,
-        boolean dailySubStatus
+        boolean dailySubStatus,
+        boolean isOauth
 ) {
     public static UserRes from(User user, List<SubNewsQueryDto> subNewsList) {
         List<String> newsNames = new ArrayList<>();
@@ -38,7 +39,8 @@ public record UserRes(
                 newsNames,
                 keywords,
                 user.isSubStatus(),
-                user.isDailySubStatus()
+                user.isDailySubStatus(),
+                user.isOauthUser()
         );
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/FcmTokenCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/FcmTokenCommandService.java
@@ -29,7 +29,7 @@ public class FcmTokenCommandService {
      */
     @Transactional
     public void registerFcmToken(Long userId, FcmTokenReq.Register registerDto) {
-        Optional<FcmToken> fcmToken = fcmTokenService.readAllByUserIdAndDeviceInfo(userId, registerDto.deviceInfo());
+        Optional<FcmToken> fcmToken = fcmTokenService.readByUserIdAndDeviceInfo(userId, registerDto.deviceInfo());
 
         if (fcmToken.isPresent()) {
             fcmToken.get().updateToken(registerDto.token());

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/FcmTokenCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/FcmTokenCommandService.java
@@ -45,12 +45,12 @@ public class FcmTokenCommandService {
      * 특정 사용자와 디바이스 정보를 기준으로 해당 FCM 토큰을 삭제하는 메서드
      * - 로그아웃 시, 사용
      *
-     * @param userId    : 사용자 pk
-     * @param deleteDto : 디바이스 정보 DTO
+     * @param userId     : 사용자 pk
+     * @param deviceInfo : 디바이스 정보
      */
     @Transactional
-    public void deleteTokenByUserAndDevice(Long userId, FcmTokenReq.Delete deleteDto) {
-        fcmTokenService.deleteByUserIdAndDeviceInfo(userId, deleteDto.deviceInfo());
+    public void deleteTokenByUserAndDevice(Long userId, String deviceInfo) {
+        fcmTokenService.deleteByUserIdAndDeviceInfo(userId, deviceInfo);
     }
 
     /**

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/UserCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/user/service/UserCommandService.java
@@ -5,7 +5,6 @@ import kr.co.yournews.auth.service.PasswordEncodeService;
 import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
-import kr.co.yournews.domain.user.service.FcmTokenService;
 import kr.co.yournews.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserCommandService {
     private final UserService userService;
     private final PasswordEncodeService passwordEncodeService;
-    private final FcmTokenService fcmTokenService;
+    private final FcmTokenCommandService fcmTokenCommandService;
 
     /**
      * 비밀번호 재설정 메서드
@@ -82,7 +81,7 @@ public class UserCommandService {
      */
     @Transactional
     public void deleteUser(Long userId) {
-        fcmTokenService.deleteAllByUserId(userId);
+        fcmTokenCommandService.deleteTokenByUserId(userId);
         userService.deleteById(userId);
     }
 }

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/AuthControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/AuthControllerTest.java
@@ -24,11 +24,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.List;
 
-import static kr.co.yournews.common.util.AuthConstants.AUTHORIZATION;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -360,28 +357,5 @@ public class AuthControllerTest {
                     .andExpect(jsonPath("$.message").value(AuthErrorType.REFRESH_TOKEN_NOT_FOUND.getMessage()))
                     .andExpect(jsonPath("$.code").value(AuthErrorType.REFRESH_TOKEN_NOT_FOUND.getCode()));
         }
-    }
-
-    @Test
-    @DisplayName("로그아웃 테스트")
-    void signOutTest() throws Exception {
-        // given
-        String accessToken = "accessToken";
-        String refreshToken = "refreshToken";
-
-        doNothing().when(authCommandService).signOut(eq(accessToken), eq(refreshToken));
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/auth/sign-out")
-                        .header("X-Refresh-Token", tokenDto.refreshToken())
-                        .header(AUTHORIZATION, accessToken)
-        );
-
-        // then
-        resultActions
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
     }
 }

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/SecuredAuthControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/SecuredAuthControllerTest.java
@@ -1,0 +1,93 @@
+package kr.co.yournews.apis.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.yournews.apis.auth.dto.SignOutDto;
+import kr.co.yournews.apis.auth.service.AuthCommandService;
+import kr.co.yournews.auth.authentication.CustomUserDetails;
+import kr.co.yournews.domain.user.entity.User;
+import kr.co.yournews.domain.user.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static kr.co.yournews.common.util.AuthConstants.AUTHORIZATION;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+public class SecuredAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthCommandService authCommandService;
+
+    private User user;
+    private UserDetails userDetails;
+    private final Long userId = 1L;
+
+    @BeforeEach
+    void setup(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+
+
+        user = User.builder()
+                .username("test")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        userDetails = CustomUserDetails.from(user);
+    }
+
+    @Test
+    @DisplayName("로그아웃 테스트")
+    void signOutTest() throws Exception {
+        // given
+        String accessToken = "accessToken";
+        String refreshToken = "refreshToken";
+        SignOutDto signOutDto = new SignOutDto("device-info");
+
+        doNothing().when(authCommandService).signOut(accessToken, refreshToken, userId, signOutDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-out")
+                        .with(user(userDetails))
+                        .header("X-Refresh-Token", refreshToken)
+                        .header(AUTHORIZATION, accessToken)
+                        .content(objectMapper.writeValueAsBytes(signOutDto))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공하였습니다."));
+    }
+}

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/auth/service/AuthCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/auth/service/AuthCommandServiceTest.java
@@ -1,8 +1,10 @@
 package kr.co.yournews.apis.auth.service;
 
 import kr.co.yournews.apis.auth.dto.RestoreUserDto;
+import kr.co.yournews.apis.auth.dto.SignOutDto;
 import kr.co.yournews.apis.auth.service.mail.AuthCodeService;
 import kr.co.yournews.apis.news.service.SubNewsCommandService;
+import kr.co.yournews.apis.user.service.FcmTokenCommandService;
 import kr.co.yournews.auth.dto.SignInDto;
 import kr.co.yournews.auth.dto.SignUpDto;
 import kr.co.yournews.auth.dto.TokenDto;
@@ -53,6 +55,9 @@ public class AuthCommandServiceTest {
 
     @Mock
     private SubNewsCommandService subNewsCommandService;
+
+    @Mock
+    private FcmTokenCommandService fcmTokenCommandService;
 
     @InjectMocks
     private AuthCommandService authCommandService;
@@ -280,9 +285,10 @@ public class AuthCommandServiceTest {
         String accessTokenInHeader = "Bearer accessToken";
         String accessToken = "accessToken";
         String refreshToken = "refreshToken";
+        SignOutDto signOutDto = new SignOutDto("device-info");
 
         // when
-        authCommandService.signOut(accessTokenInHeader, refreshToken);
+        authCommandService.signOut(accessTokenInHeader, refreshToken, userId, signOutDto);
 
         // then
         verify(jwtHelper, times(1)).removeToken(accessToken, refreshToken);

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/mail/controller/MailControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/mail/controller/MailControllerTest.java
@@ -1,9 +1,8 @@
 package kr.co.yournews.apis.mail.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.yournews.apis.auth.mail.controller.MailController;
-import kr.co.yournews.apis.auth.mail.dto.InquiryMailReq;
-import kr.co.yournews.apis.auth.mail.service.InquiryMailer;
+import kr.co.yournews.apis.mail.dto.InquiryMailReq;
+import kr.co.yournews.apis.mail.service.InquiryMailer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/controller/FcmTokenControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/controller/FcmTokenControllerTest.java
@@ -94,7 +94,7 @@ public class FcmTokenControllerTest {
         // given
         FcmTokenReq.Delete dto = new FcmTokenReq.Delete("iPhone15");
 
-        doNothing().when(fcmTokenCommandService).deleteTokenByUserAndDevice(userId, dto);
+        doNothing().when(fcmTokenCommandService).deleteTokenByUserAndDevice(userId, dto.deviceInfo());
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/FcmTokenCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/FcmTokenCommandServiceTest.java
@@ -51,7 +51,7 @@ public class FcmTokenCommandServiceTest {
         void registerFcmTokenUpdate() {
             // given
             FcmToken existingToken = mock(FcmToken.class);
-            given(fcmTokenService.readAllByUserIdAndDeviceInfo(userId, deviceInfo))
+            given(fcmTokenService.readByUserIdAndDeviceInfo(userId, deviceInfo))
                     .willReturn(Optional.of(existingToken));
 
             FcmTokenReq.Register dto = new FcmTokenReq.Register(token, deviceInfo);
@@ -68,7 +68,7 @@ public class FcmTokenCommandServiceTest {
         @DisplayName("성공 - 기존 디바이스가 없을 경우 새로 저장")
         void registerFcmTokenSaveNew() {
             // given
-            given(fcmTokenService.readAllByUserIdAndDeviceInfo(userId, deviceInfo))
+            given(fcmTokenService.readByUserIdAndDeviceInfo(userId, deviceInfo))
                     .willReturn(Optional.empty());
 
             User user = mock(User.class);
@@ -87,7 +87,7 @@ public class FcmTokenCommandServiceTest {
         @DisplayName("실패 - 사용자 정보 없음")
         void registerFcmTokenUserNotFound() {
             // given
-            given(fcmTokenService.readAllByUserIdAndDeviceInfo(userId, deviceInfo))
+            given(fcmTokenService.readByUserIdAndDeviceInfo(userId, deviceInfo))
                     .willReturn(Optional.empty());
 
             given(userService.readById(userId)).willReturn(Optional.empty());

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/FcmTokenCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/FcmTokenCommandServiceTest.java
@@ -111,10 +111,9 @@ public class FcmTokenCommandServiceTest {
         @DisplayName("성공 - 디바이스 정보 기반 FCM 토큰 삭제")
         void deleteTokenByUserAndDevice() {
             // given
-            FcmTokenReq.Delete dto = new FcmTokenReq.Delete(deviceInfo);
 
             // when
-            fcmTokenCommandService.deleteTokenByUserAndDevice(userId, dto);
+            fcmTokenCommandService.deleteTokenByUserAndDevice(userId, deviceInfo);
 
             // then
             verify(fcmTokenService).deleteByUserIdAndDeviceInfo(userId, deviceInfo);

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/UserCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/user/service/UserCommandServiceTest.java
@@ -5,7 +5,6 @@ import kr.co.yournews.auth.service.PasswordEncodeService;
 import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
-import kr.co.yournews.domain.user.service.FcmTokenService;
 import kr.co.yournews.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,7 +35,7 @@ public class UserCommandServiceTest {
     private PasswordEncodeService passwordEncodeService;
 
     @Mock
-    private FcmTokenService fcmTokenService;
+    private FcmTokenCommandService fcmTokenCommandService;
 
     @InjectMocks
     private UserCommandService userCommandService;
@@ -221,6 +220,6 @@ public class UserCommandServiceTest {
 
         // then
         verify(userService, times(1)).deleteById(userId);
-        verify(fcmTokenService, times(1)).deleteAllByUserId(userId);
+        verify(fcmTokenCommandService, times(1)).deleteTokenByUserId(userId);
     }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/entity/User.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/entity/User.java
@@ -44,7 +44,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -111,5 +111,9 @@ public class User extends BaseTimeEntity {
 
     public void restore() {
         this.deletedAt = null;
+    }
+
+    public boolean isOauthUser() {
+        return this.platform != null;
     }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/service/FcmTokenService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/service/FcmTokenService.java
@@ -25,7 +25,7 @@ public class FcmTokenService {
         return fcmTokenRepository.findAllByUserIdIn(userIds);
     }
 
-    public Optional<FcmToken> readAllByUserIdAndDeviceInfo(Long userId, String deviceInfo) {
+    public Optional<FcmToken> readByUserIdAndDeviceInfo(Long userId, String deviceInfo) {
         return fcmTokenRepository.findByUser_IdAndDeviceInfo(userId, deviceInfo);
     }
 


### PR DESCRIPTION
## 배경
로그아웃 후, 푸시 알림 전송을 막기 위한 토큰 삭제 필요.

## 작업 사항
 - 로그아웃 후, 푸시 알림 전송을 막기 위한 토큰 삭제
 -  FCM 토큰 삭제 로직 매개변수 변경
 -  OAuth 로그인 확인을 위한 필드 추가