### PR TITLE
Feature: 관리자 게시글 관리 로직 구현

### DIFF
--- a/yournews-admin/build.gradle
+++ b/yournews-admin/build.gradle
@@ -9,5 +9,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    /* Security */
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/yournews-admin/src/main/java/kr/co/yournews/admin/post/controller/PostManagementController.java
+++ b/yournews-admin/src/main/java/kr/co/yournews/admin/post/controller/PostManagementController.java
@@ -1,0 +1,81 @@
+package kr.co.yournews.admin.post.controller;
+
+import jakarta.validation.Valid;
+import kr.co.yournews.admin.post.dto.PostDto;
+import kr.co.yournews.admin.post.service.PostManagementCommandService;
+import kr.co.yournews.admin.post.service.PostManagementQueryService;
+import kr.co.yournews.auth.authentication.CustomUserDetails;
+import kr.co.yournews.common.response.success.SuccessResponse;
+import kr.co.yournews.domain.post.type.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/posts")
+@RequiredArgsConstructor
+public class PostManagementController {
+    private final PostManagementCommandService postManagementCommandService;
+    private final PostManagementQueryService postManagementQueryService;
+
+    @PostMapping
+    public ResponseEntity<?> createPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid PostDto.Request request) {
+
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        postManagementCommandService.createPost(userDetails.getUserId(), request)
+                )
+        );
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<?> getPostById(@PathVariable Long postId) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        postManagementQueryService.getPostById(postId)
+                )
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getPostsByCategory(
+            @RequestParam Category category,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        postManagementQueryService.getPostsByCategory(category, pageable)
+                )
+        );
+    }
+
+    @PutMapping("/{postId}")
+    public ResponseEntity<?> updatePost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid PostDto.Request request,
+            @PathVariable Long postId
+    ) {
+        postManagementCommandService.updatePost(userDetails.getUserId(), postId, request);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<?> deletePost(@PathVariable Long postId) {
+        postManagementCommandService.deletePost(postId);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}

--- a/yournews-admin/src/main/java/kr/co/yournews/admin/post/dto/PostDto.java
+++ b/yournews-admin/src/main/java/kr/co/yournews/admin/post/dto/PostDto.java
@@ -1,0 +1,36 @@
+package kr.co.yournews.admin.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import kr.co.yournews.domain.post.entity.Post;
+import kr.co.yournews.domain.post.type.Category;
+import kr.co.yournews.domain.user.entity.User;
+
+public class PostDto {
+
+    public record Request(
+            @NotBlank(message = "제목은 필수 입력입니다.")
+            @Size(max = 50, message = "제목은 최대 50자까지 작성할 수 있습니다.")
+            String title,
+
+            @NotBlank(message = "내용은 필수 입력입니다.")
+            String content
+    ) {
+        public Post toEntity(User user) {
+            return Post.builder()
+                    .title(title)
+                    .content(content)
+                    .category(Category.NOTICE)
+                    .user(user)
+                    .build();
+        }
+    }
+
+    public record Response(
+            Long id
+    ) {
+        public static Response of(Long id) {
+            return new Response(id);
+        }
+    }
+}

--- a/yournews-admin/src/main/java/kr/co/yournews/admin/post/dto/PostInfoDto.java
+++ b/yournews-admin/src/main/java/kr/co/yournews/admin/post/dto/PostInfoDto.java
@@ -1,0 +1,35 @@
+package kr.co.yournews.admin.post.dto;
+
+import kr.co.yournews.domain.post.dto.PostQueryDto;
+
+import java.time.LocalDateTime;
+
+public class PostInfoDto {
+
+    public record Summary(
+            Long id,
+            String title,
+            String nickname,
+            LocalDateTime createdAt,
+            Long likeCount
+    ) {
+        public static Summary from(PostQueryDto.Summary dto) {
+            return new Summary(dto.id(), dto.title(), dto.nickname(), dto.createdAt(), dto.likeCount());
+        }
+    }
+
+    public record Details(
+            Long id,
+            String title,
+            String content,
+            String nickname,
+            LocalDateTime createdAt,
+            Long userId,
+            Long likeCount
+    ) {
+        public static Details from(PostQueryDto.DetailsForAdmin dto) {
+            return new Details(dto.id(), dto.title(), dto.content(), dto.nickname(),
+                    dto.createdAt(), dto.userId(), dto.likeCount());
+        }
+    }
+}

--- a/yournews-admin/src/main/java/kr/co/yournews/admin/post/service/PostManagementCommandService.java
+++ b/yournews-admin/src/main/java/kr/co/yournews/admin/post/service/PostManagementCommandService.java
@@ -1,0 +1,70 @@
+package kr.co.yournews.admin.post.service;
+
+import kr.co.yournews.admin.post.dto.PostDto;
+import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.domain.post.entity.Post;
+import kr.co.yournews.domain.post.exception.PostErrorType;
+import kr.co.yournews.domain.post.service.PostLikeService;
+import kr.co.yournews.domain.post.service.PostService;
+import kr.co.yournews.domain.user.entity.User;
+import kr.co.yournews.domain.user.exception.UserErrorType;
+import kr.co.yournews.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostManagementCommandService {
+    private final UserService userService;
+    private final PostService postService;
+    private final PostLikeService postLikeService;
+
+    /**
+     * 게시글 (공지사항) 생성 메서드
+     *
+     * @param userId  : 게시글을 작성하는 사용자 ID (관리자)
+     * @param request : 생성할 게시글의 제목 및 내용 정보를 담은 DTO
+     * @return : 생성된 게시글의 ID를 담은 응답 DTO
+     * @throws CustomException NOT_FOUND: 사용자가 존재하지 않을 경우
+     */
+    @Transactional
+    public PostDto.Response createPost(Long userId, PostDto.Request request) {
+        User user = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        Long postId = postService.save(request.toEntity(user));
+
+        return PostDto.Response.of(postId);
+    }
+
+    /**
+     * 게시글 (공지사항) 업데이트 메서드
+     *
+     * @param postId : 삭제할 게시글 ID
+     * @throws CustomException NOT_FOUND: 게시글이 존재하지 않을 경우
+     *                         FORBIDDEN: 작성자가 아닐 경우
+     */
+    @Transactional
+    public void updatePost(Long userId, Long postId, PostDto.Request request) {
+        Post post = postService.readById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorType.NOT_FOUND));
+
+        if (!post.isAuthor(userId)) {
+            throw new CustomException(PostErrorType.FORBIDDEN);
+        }
+
+        post.updateInfo(request.title(), request.content());
+    }
+
+    /**
+     * 게시글 (공지사항 및 사용자 게시글) 삭제 메서드
+     *
+     * @param postId : 삭제할 게시글 ID
+     */
+    @Transactional
+    public void deletePost(Long postId) {
+        postLikeService.deleteAllByPostId(postId);
+        postService.deleteById(postId);
+    }
+}

--- a/yournews-admin/src/main/java/kr/co/yournews/admin/post/service/PostManagementQueryService.java
+++ b/yournews-admin/src/main/java/kr/co/yournews/admin/post/service/PostManagementQueryService.java
@@ -1,0 +1,46 @@
+package kr.co.yournews.admin.post.service;
+
+import kr.co.yournews.admin.post.dto.PostInfoDto;
+import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.domain.post.dto.PostQueryDto;
+import kr.co.yournews.domain.post.exception.PostErrorType;
+import kr.co.yournews.domain.post.service.PostService;
+import kr.co.yournews.domain.post.type.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostManagementQueryService {
+    private final PostService postService;
+
+    /**
+     * 게시글 조회 메서드
+     *
+     * @param postId : 조회할 게시글 pk값
+     * @return : 게시글 정보
+     */
+    @Transactional(readOnly = true)
+    public PostInfoDto.Details getPostById(Long postId) {
+        PostQueryDto.DetailsForAdmin details = postService.readDetailsById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorType.NOT_FOUND));
+
+        return PostInfoDto.Details.from(details);
+    }
+
+    /**
+     * 게시글 카테고리 조회 메서드
+     *
+     * @param category : 조회할 카테고리
+     * @param pageable : 페이징
+     * @return : 카테고리별 게시글 정보
+     */
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto.Summary> getPostsByCategory(Category category, Pageable pageable) {
+        return postService.readByCategory(category, pageable)
+                .map(PostInfoDto.Summary::from);
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/post/service/PostCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/post/service/PostCommandService.java
@@ -4,6 +4,7 @@ import kr.co.yournews.apis.post.dto.PostDto;
 import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.post.entity.Post;
 import kr.co.yournews.domain.post.exception.PostErrorType;
+import kr.co.yournews.domain.post.service.PostLikeService;
 import kr.co.yournews.domain.post.service.PostService;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostCommandService {
     private final UserService userService;
     private final PostService postService;
+    private final PostLikeService postLikeService;
 
     /**
      * 게시글 생성 메서드
@@ -37,10 +39,10 @@ public class PostCommandService {
     }
 
     /**
-     * 게시글 삭제 메서드
+     * 게시글 업데이트 메서드
      *
      * @param userId : 요청한 사용자 ID
-     * @param postId : 삭제할 게시글 ID
+     * @param postId : 업데이트할 게시글 ID
      * @throws CustomException NOT_FOUND: 게시글이 존재하지 않을 경우
      *                         FORBIDDEN: 작성자가 아닐 경우
      */
@@ -73,6 +75,7 @@ public class PostCommandService {
             throw new CustomException(PostErrorType.FORBIDDEN);
         }
 
+        postLikeService.deleteAllByPostId(postId);
         postService.deleteById(postId);
     }
 }

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/post/service/PostCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/post/service/PostCommandServiceTest.java
@@ -4,6 +4,7 @@ import kr.co.yournews.apis.post.dto.PostDto;
 import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.post.entity.Post;
 import kr.co.yournews.domain.post.exception.PostErrorType;
+import kr.co.yournews.domain.post.service.PostLikeService;
 import kr.co.yournews.domain.post.service.PostService;
 import kr.co.yournews.domain.user.entity.User;
 import kr.co.yournews.domain.user.exception.UserErrorType;
@@ -35,6 +36,9 @@ public class PostCommandServiceTest {
 
     @Mock
     private PostService postService;
+
+    @Mock
+    private PostLikeService postLikeService;
 
     @InjectMocks
     private PostCommandService postCommandService;
@@ -157,6 +161,7 @@ public class PostCommandServiceTest {
             postCommandService.deletePost(userId, postId);
 
             // then
+            verify(postLikeService, times(1)).deleteAllByPostId(postId);
             verify(postService, times(1)).deleteById(postId);
         }
 

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/dto/PostQueryDto.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/dto/PostQueryDto.java
@@ -22,4 +22,14 @@ public class PostQueryDto {
             Long likeCount,
             Boolean liked
     ) { }
+
+    public record DetailsForAdmin(
+            Long id,
+            String title,
+            String content,
+            String nickname,
+            LocalDateTime createdAt,
+            Long userId,
+            Long likeCount
+    ) { }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/CustomPostRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/CustomPostRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface CustomPostRepository {
     Page<PostQueryDto.Summary> findAllByCategory(Category category, Pageable pageable);
     Optional<PostQueryDto.Details> findDetailsById(Long postId, Long userId);
+    Optional<PostQueryDto.DetailsForAdmin> findDetailsById(Long postId);
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/CustomPostRepositoryImpl.java
@@ -86,4 +86,28 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
         return Optional.ofNullable(details);
     }
+
+    @Override
+    public Optional<PostQueryDto.DetailsForAdmin> findDetailsById(Long postId) {
+        PostQueryDto.DetailsForAdmin details = jpaQueryFactory
+                .select(Projections.constructor(
+                        PostQueryDto.DetailsForAdmin.class,
+                        post.id,
+                        post.title,
+                        post.content,
+                        user.nickname.coalesce(User.UNKNOWN_NICKNAME),
+                        post.createdAt,
+                        post.userId,
+                        JPAExpressions
+                                .select(postLike.count())
+                                .from(postLike)
+                                .where(postLike.post.id.eq(post.id))
+                ))
+                .from(post)
+                .leftJoin(post.user, user)
+                .where(post.id.eq(postId))
+                .fetchOne();
+
+        return Optional.ofNullable(details);
+    }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/PostLikeRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/repository/PostLikeRepository.java
@@ -15,4 +15,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     @Modifying
     @Query("DELETE FROM post_like p WHERE p.user.id IN :userIds")
     void deleteAllByUserIds(@Param("userIds") List<Long> userIds);
+
+    @Modifying
+    @Query("DELETE FROM post_like p WHERE p.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/service/PostLikeService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/service/PostLikeService.java
@@ -24,6 +24,10 @@ public class PostLikeService {
         postLikeRepository.deleteAllByUserIds(userIds);
     }
 
+    public void deleteAllByPostId(Long postId) {
+        postLikeRepository.deleteAllByPostId(postId);
+    }
+
     public boolean existsByUserIdAndPostId(Long userId, Long poseId) {
         return postLikeRepository.existsByUser_IdAndPost_Id(userId, poseId);
     }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/post/service/PostService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/post/service/PostService.java
@@ -28,6 +28,10 @@ public class PostService {
         return postRepository.findDetailsById(postId, userId);
     }
 
+    public Optional<PostQueryDto.DetailsForAdmin> readDetailsById(Long postId) {
+        return postRepository.findDetailsById(postId);
+    }
+
     public Page<PostQueryDto.Summary> readByCategory(Category category, Pageable pageable) {
         return postRepository.findAllByCategory(category, pageable);
     }


### PR DESCRIPTION
## 배경
게시글 관리 로직이 필요

## 작업 사항
- postId를 통한 게시글 좋아요 삭제 로직 구현 - 게시글 삭제 시 외래키 제약조건 때문 (e37f1e20fd76117b94a5ac52808fe6283f517bb3)
    - 게시글 삭제 전, 좋아요 삭제 추가 (0e500007bf67fbc2044067449abb7718b12946b8)
- 관리자 게시글 읽기 로직 구현 (0a31d9e849726bcf68618fec7b91bfeed4e0aceb)
- 관리자 게시글 쓰기 로직 구현 (527e849e2eb3fa021f99eed67773620d6859a585)