### PR TITLE
Feature: 비밀번호 재설정 예외처리 추가 및 View 구현

### DIFF
--- a/yournews-apis/build.gradle
+++ b/yournews-apis/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
 	/* Web */
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	/* Security */
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/PassResetController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/controller/PassResetController.java
@@ -1,0 +1,13 @@
+package kr.co.yournews.apis.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PassResetController {
+
+    @GetMapping("/pass-reset")
+    public String passResetPage() {
+        return "pass-reset";
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/mail/PassCodeManager.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/mail/PassCodeManager.java
@@ -40,7 +40,6 @@ public class PassCodeManager {
                 uuid,
                 mailStrategyFactory.getStrategy(MailType.PASS)
         );
-        System.out.println(uuid);
     }
 
     /**
@@ -51,9 +50,7 @@ public class PassCodeManager {
      */
     @Transactional
     public void applyNewPassword(PassResetDto.ResetPassword resetPasswordDto) {
-        if (!passCodeService.validateResetUuid(resetPasswordDto.username(), resetPasswordDto.uuid())) {
-            throw new CustomException(UserErrorType.UNAUTHORIZED_ACTION);
-        }
+        passCodeService.validateResetUuid(resetPasswordDto.username(), resetPasswordDto.uuid());
 
         User user = userService.readByUsername(resetPasswordDto.username())
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/mail/PassCodeService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/auth/service/mail/PassCodeService.java
@@ -1,5 +1,7 @@
 package kr.co.yournews.apis.auth.service.mail;
 
+import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.domain.user.exception.UserErrorType;
 import kr.co.yournews.infra.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,17 +41,19 @@ public class PassCodeService {
      *
      * @param username : 사용자 아이디
      * @param uuid     : 전달한 uuid
-     * @return : 검증 결과 (true: 일치함)
      */
-    public boolean validateResetUuid(String username, String uuid) {
+    public void validateResetUuid(String username, String uuid) {
         String key = PASS_KEY_PREFIX + username;
         String savedCode = (String) redisRepository.get(key);
 
-        if (savedCode == null || !savedCode.equals(uuid)) {
-            return false;
+        if (savedCode == null) {
+            throw new CustomException(UserErrorType.EXPIRED_PASSWORD_RESET_CODE);
+        }
+
+        if (!uuid.equals(savedCode)) {
+            throw new CustomException(UserErrorType.INVALID_PASSWORD_RESET_REQUEST);
         }
 
         redisRepository.del(key);
-        return true;
     }
 }

--- a/yournews-apis/src/main/resources/static/pass-reset/css/reset.css
+++ b/yournews-apis/src/main/resources/static/pass-reset/css/reset.css
@@ -1,0 +1,70 @@
+body {
+    background-color: #f9f9fb;
+    font-family: 'Segoe UI', sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background: white;
+    padding: 30px 40px;
+    border-radius: 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    max-width: 400px;
+    box-sizing: border-box;
+}
+
+h2 {
+    margin-bottom: 24px;
+    text-align: center;
+}
+
+input {
+    width: 100%;
+    padding: 12px;
+    margin-bottom: 14px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 14px;
+}
+
+button {
+    width: 100%;
+    padding: 14px;
+    background-color: #4a90e2;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-weight: bold;
+    font-size: 15px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #3a76c4;
+}
+
+.info {
+    margin-top: 16px;
+    font-size: 14px;
+    color: #777;
+    text-align: center;
+}
+
+.error {
+    color: #d32f2f;
+    font-size: 13px;
+    margin-top: 10px;
+    text-align: center;
+}
+
+.success {
+    color: #388e3c;
+    font-size: 13px;
+    margin-top: 10px;
+    text-align: center;
+}

--- a/yournews-apis/src/main/resources/static/pass-reset/js/pass-reset.js
+++ b/yournews-apis/src/main/resources/static/pass-reset/js/pass-reset.js
@@ -1,0 +1,61 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const form = document.getElementById("reset-form");
+    const passwordInput = document.getElementById("password");
+    const passwordCheckInput = document.getElementById("password-check");
+    const usernameInput = document.getElementById("username");
+    const errorMsg = document.getElementById("error-message");
+    const successMsg = document.getElementById("success-message");
+
+    const queryParams = new URLSearchParams(window.location.search);
+    const uuid = queryParams.get("code");
+
+    if (!uuid) {
+        errorMsg.textContent = "잘못된 접근입니다.";
+        form.style.display = "none";
+        return;
+    }
+
+    form.addEventListener("submit", async function (e) {
+        e.preventDefault();
+        errorMsg.textContent = "";
+        successMsg.textContent = "";
+
+        const username = usernameInput.value.trim();
+        const password = passwordInput.value.trim();
+        const passwordCheck = passwordCheckInput.value.trim();
+
+        if (!username || !password || !passwordCheck) {
+            errorMsg.textContent = "모든 항목을 입력해주세요.";
+            return;
+        }
+
+        if (password !== passwordCheck) {
+            errorMsg.textContent = "비밀번호가 일치하지 않습니다.";
+            return;
+        }
+
+        const pattern = /(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\W).{8,16}/;
+        if (!pattern.test(password)) {
+            errorMsg.textContent = "비밀번호는 8~16자 영문, 숫자, 특수문자를 포함해야 합니다.";
+            return;
+        }
+
+        try {
+            const res = await fetch("/api/v1/auth/password/reset", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ username, uuid, password }),
+            });
+
+            if (!res.ok) {
+                const json = await res.json();
+                throw new Error(json?.message || "비밀번호 재설정 실패");
+            }
+
+            successMsg.textContent = "✅ 비밀번호가 성공적으로 변경되었습니다.";
+            form.reset();
+        } catch (err) {
+            errorMsg.textContent = err.message;
+        }
+    });
+});

--- a/yournews-apis/src/main/resources/templates/pass-reset.html
+++ b/yournews-apis/src/main/resources/templates/pass-reset.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>Your-News</title>
+    <link rel="stylesheet" href="/pass-reset/css/reset.css" />
+</head>
+<body>
+<div class="container">
+    <h2>🔒 비밀번호 재설정</h2>
+
+    <form id="reset-form">
+        <input type="text" id="username" placeholder="아이디" required />
+
+        <input type="password" id="password" placeholder="새 비밀번호" required />
+
+        <input type="password" id="password-check" placeholder="비밀번호 확인" required />
+
+        <button type="submit">비밀번호 변경</button>
+        <p class="info">비밀번호 재설정 링크는 10분간만 유효합니다.</p>
+    </form>
+
+    <p class="error" id="error-message"></p>
+    <p class="success" id="success-message"></p>
+</div>
+
+<script src="/pass-reset/js/pass-reset.js"></script>
+</body>
+</html>

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/AuthSupportControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/auth/controller/AuthSupportControllerTest.java
@@ -304,7 +304,7 @@ public class AuthSupportControllerTest {
                     "user1", "wrong-uuid", "Abcdefg123!"
             );
 
-            doThrow(new CustomException(UserErrorType.UNAUTHORIZED_ACTION))
+            doThrow(new CustomException(UserErrorType.INVALID_PASSWORD_RESET_REQUEST))
                     .when(passCodeManager).applyNewPassword(dto);
 
             // when
@@ -316,9 +316,9 @@ public class AuthSupportControllerTest {
 
             // then
             resultActions
-                    .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.code").value(UserErrorType.UNAUTHORIZED_ACTION.getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorType.UNAUTHORIZED_ACTION.getMessage()));
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(UserErrorType.INVALID_PASSWORD_RESET_REQUEST.getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorType.INVALID_PASSWORD_RESET_REQUEST.getMessage()));
         }
     }
 

--- a/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
+++ b/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/api/v1/auth/**", "/api/v1/admin/auth/sign-in",
             "/api/v1/oauth/sign-in/**", "/api/v1/news/**",
-            "/admin/**", "/favicon.ico"
+            "/admin/**", "/favicon.ico", "/pass-reset/**"
     };
     private static final String[] ADMIN_ENDPOINTS = {"/api/v1/admin/**"};
     private static final String[] GUEST_ENDPOINTS = {"/api/v1/oauth/sign-up"};

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/exception/UserErrorType.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/exception/UserErrorType.java
@@ -17,13 +17,14 @@ public enum UserErrorType implements BaseErrorType {
     CODE_EXPIRED(StatusCode.GONE, "U005", "유효시간이 지났습니다."),
     INVALID_CODE(StatusCode.BAD_REQUEST, "U006", "인증번호가 일치하지 않습니다."),
     INVALID_USER_INFO(StatusCode.BAD_REQUEST, "U007", "정보를 정확히 입력해주세요."),
-    UNAUTHORIZED_ACTION(StatusCode.FORBIDDEN, "U008", "권한이 없습니다."),
     CODE_NOT_VERIFIED(StatusCode.FORBIDDEN, "U009", "이메일 인증을 완료해주세요."),
     EXIST_NICKNAME(StatusCode.CONFLICT, "U010", "이미 존재하는 닉네임입니다."),
     DEACTIVATED(StatusCode.FORBIDDEN, "U011", "탈퇴한 사용자입니다."),
     ALREADY_ACTIVE(StatusCode.CONFLICT, "U012", "이미 활성화된 사용자입니다."),
     NOT_ADMIN(StatusCode.FORBIDDEN, "U013", "관리자 권한이 없습니다."),
     BANNED(StatusCode.FORBIDDEN, "U014", "정지된 사용자입니다. 관리자에게 문의해주세요."),
+    INVALID_PASSWORD_RESET_REQUEST(StatusCode.BAD_REQUEST, "U015", "아이디 또는 인증 정보가 올바르지 않습니다."),
+    EXPIRED_PASSWORD_RESET_CODE(StatusCode.BAD_REQUEST, "U016", "비밀번호 재설정 링크가 만료되었습니다. 다시 요청해주세요."),
     ;
 
     private final StatusCode status;


### PR DESCRIPTION
## 배경
사용자에게 정확한 예외 문구를 알려줘야 함.
비밀번호 재설정을 할 수 있는 페이지 제공이 필요.

## 작업 사항
- 패스워드 예외 처리 로직 설정 변경 (71d8bae13a56800ea4fd0de205128aa830a6b204)
- 비밀번호 재설정 View 구현 (e87be7efab0c63871e9206c0e36073180987262f)