### PR TITLE
Refactor: Soft delete 사용자 정보 조회 쿼리 수정

### DIFF
--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/UserRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/repository/UserRepository.java
@@ -12,17 +12,25 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
     Optional<User> findByUsername(String username);
-    Optional<User> findByEmail(String email);
-    boolean existsByEmail(String email);
-    boolean existsByUsername(String username);
-    boolean existsByNickname(String nickname);
     boolean existsByUsernameAndEmail(String username, String email);
+
+    @Query(value = "SELECT * FROM user WHERE email = :email", nativeQuery = true)
+    Optional<User> findByEmailIncludeDeleted(@Param("email") String email);
 
     @Query(value = "SELECT * FROM user WHERE username = :username", nativeQuery = true)
     Optional<User> findByUsernameIncludeDeleted(@Param("username") String username);
 
     @Query(value = "SELECT id FROM user WHERE deleted_at IS NOT NULL AND deleted_at <= :dateTime", nativeQuery = true)
     List<Long> findSoftDeletedUserIdsBefore(@Param("dateTime") LocalDate dateTime);
+
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM user WHERE email = :email)", nativeQuery = true)
+    Long existsByEmailIncludeDeleted(@Param("email") String email);
+
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM user WHERE username = :username)", nativeQuery = true)
+    Long existsByUsernameIncludeDeleted(@Param("username") String username);
+
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM user WHERE nickname = :nickname)", nativeQuery = true)
+    Long existsByNicknameIncludeDeleted(@Param("nickname") String nickname);
 
     @Modifying
     @Query(value = "DELETE FROM user WHERE id IN :ids", nativeQuery = true)

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/user/service/UserService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/user/service/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
     }
 
     public Optional<User> readByEmail(String email) {
-        return userRepository.findByEmail(email);
+        return userRepository.findByEmailIncludeDeleted(email);
     }
 
     public List<Long> readAllUserIdsByNewsNameAndSubStatusTrue(String newsName) {
@@ -57,15 +57,15 @@ public class UserService {
     }
 
     public boolean existsByEmail(String email) {
-        return userRepository.existsByEmail(email);
+        return userRepository.existsByEmailIncludeDeleted(email) == 1;
     }
 
     public boolean existsByUsername(String username) {
-        return userRepository.existsByUsername(username);
+        return userRepository.existsByUsernameIncludeDeleted(username) == 1;
     }
 
     public boolean existsByNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
+        return userRepository.existsByNicknameIncludeDeleted(nickname) == 1;
     }
 
     public boolean existsByUsernameAndEmail(String username, String email) {


### PR DESCRIPTION
## 배경
Soft delete된 사용자의 정보 조회 로직이 필요
ex) 아이디, 닉네임, 이메일 중복확인. 아이디 찾기 등

## 작업 사항
 - nativeQuery를 통해서 Soft delete된 사용자 정보 조회 (07758d013d473d034abf067ecadc69146e6b3e1d)

## 기타
복잡성이 커질 경우, SQL 기반 Query DSL 도입 필요