### PR TITLE
Fix: 타입 불일치로 인한 JPQL 동작 오류 해결

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationCommandService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -52,7 +53,7 @@ public class NotificationCommandService {
      */
     @Transactional
     public void deleteOldNotification() {
-        LocalDate dateTime = LocalDate.now().minusDays(10);
+        LocalDateTime dateTime = LocalDate.now().minusDays(10).atStartOfDay();
         log.info("[오래된 알림 삭제 요청] 기준일: {}", dateTime);
 
         notificationService.deleteByDateTime(dateTime);

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/notification/service/NotificationCommandServiceTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/notification/service/NotificationCommandServiceTest.java
@@ -12,7 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -120,6 +120,6 @@ public class NotificationCommandServiceTest {
         notificationCommandService.deleteOldNotification();
 
         // then
-        verify(notificationService, times(1)).deleteByDateTime(any(LocalDate.class));
+        verify(notificationService, times(1)).deleteByDateTime(any(LocalDateTime.class));
     }
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NotificationRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NotificationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, CustomNotificationRepository {
@@ -19,5 +19,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Modifying
     @Query("DELETE FROM notification n WHERE n.createdAt < :dateTime")
-    void deleteByDateTimeBefore(@Param("dateTime") LocalDate dateTime);
+    void deleteByDateTimeBefore(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NotificationService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NotificationService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +44,7 @@ public class NotificationService {
         notificationRepository.deleteById(id);
     }
 
-    public void deleteByDateTime(LocalDate dateTime) {
+    public void deleteByDateTime(LocalDateTime dateTime) {
         notificationRepository.deleteByDateTimeBefore(dateTime);
     }
 }


### PR DESCRIPTION
## 배경
JPQL에서는 타입을 동일하게 맞춰야함. (LocalDateTime 타입을 LocalDate로 진행했기 때문에 분제 발생)

## 작업 사항
- Query 조회 타입 LocalDate -> LocalDateType 변환 (34793d6a7e5d61cab8b2ec6e79ebd22c94172026)