### PR TITLE
Feature: Guest 로그인을 위한 설정 추가

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/post/controller/PostController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/post/controller/PostController.java
@@ -43,9 +43,11 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<?> getPostById(@AuthenticationPrincipal CustomUserDetails userDetails,
                                          @PathVariable Long postId) {
+        Long userId = (userDetails != null) ? userDetails.getUserId() : null;
+
         return ResponseEntity.ok(
                 SuccessResponse.from(
-                        postQueryService.getPostById(postId, userDetails.getUserId())
+                        postQueryService.getPostById(postId, userId)
                 )
         );
     }

--- a/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
+++ b/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .requestMatchers(ADMIN_ENDPOINTS).hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.POST, GUEST_ENDPOINTS).hasRole(Role.GUEST.name())


### PR DESCRIPTION
## 배경
앱스토어의 경우, 로그인이 필수적이지 않은 기능 (ex. 게시글 조회)에는 로그인을 강제하면 안됨.
게시글의 경우가 해당되어 게스트 로그인의 경우에 대한 처리 추가

## 작업 사항
- 게스트 로그인을 위한 게시글 조회 시큐리티 허용 엔드포인트 추가 (7646c2d39e90fda0da079766d8328a20301fef74)
- 게스트 로그인 시, 게시글 조회 중 좋아요 확인 false 고정 (8c50981f5751df41cd45b808871b06b2e241bfbe)
- 게스트 로그인일 시, userId null 처리 (e736f8764e441fef5d494494f563a03e3f297b70)