### PR TITLE
Feature: 소식 랭킹 조회 로직 추가

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/controller/NotificationController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package kr.co.yournews.apis.notification.controller;
 import kr.co.yournews.apis.notification.dto.NotificationDto;
 import kr.co.yournews.apis.notification.service.NotificationCommandService;
 import kr.co.yournews.apis.notification.service.NotificationQueryService;
+import kr.co.yournews.apis.notification.service.NotificationRankingService;
 import kr.co.yournews.auth.authentication.CustomUserDetails;
 import kr.co.yournews.common.response.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
     private final NotificationCommandService notificationCommandService;
     private final NotificationQueryService notificationQueryService;
+    private final NotificationRankingService notificationRankingService;
 
     @GetMapping("/id/{notificationId}")
     public ResponseEntity<?> getNotificationById(@PathVariable Long notificationId) {
@@ -62,6 +64,15 @@ public class NotificationController {
         return ResponseEntity.ok(
                 SuccessResponse.from(
                         notificationQueryService.getUnreadCount(userDetails.getUserId())
+                )
+        );
+    }
+
+    @GetMapping("/rank")
+    public ResponseEntity<?> getTopNewsRanking() {
+        return ResponseEntity.ok(
+                SuccessResponse.from(
+                        notificationRankingService.getTopNewsRanking()
                 )
         );
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/dto/NotificationRankingDto.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/dto/NotificationRankingDto.java
@@ -1,0 +1,10 @@
+package kr.co.yournews.apis.notification.dto;
+
+public record NotificationRankingDto(
+        String name,
+        int score
+) {
+    public NotificationRankingDto of(String name, int score) {
+        return new NotificationRankingDto(name, score);
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/DailyNotificationService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/DailyNotificationService.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class DailyNotificationService {
     private final RedisRepository redisRepository;
+    private final NotificationRankingService notificationRankingService;
 
     /**
      * 일간 알림을 위한 소식 이름을 기반으로 제목과 URL 정보를 Redis에 저장하는 메서드
@@ -30,6 +31,8 @@ public class DailyNotificationService {
                 .toList();
 
         redisRepository.setListAll(key, dailyNewsDtos);
+        // 소식의 알림 수를 기준으로 ZSet에서 점수 갱신 (랭킹 업데이트)
+        notificationRankingService.incrementNewsRanking(newsName, dailyNewsDtos.size());
 
         log.info("[새로운 소식 저장 완료] newsName: {}, 저장 개수: {}, key: {}", newsName, dailyNewsDtos.size(), key);
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationRankingService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationRankingService.java
@@ -1,0 +1,61 @@
+package kr.co.yournews.apis.notification.service;
+
+import kr.co.yournews.apis.notification.dto.NotificationRankingDto;
+import kr.co.yournews.infra.redis.RedisRepository;
+import kr.co.yournews.infra.redis.util.RedisConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationRankingService {
+    private final RedisRepository redisRepository;
+
+    private static final int TOP_N = 3;
+
+    /**
+     * 소식 이름(newsName)을 기준으로 Redis ZSet 내 점수를 증가시키는 메서드
+     * - ZSet 구조를 사용하여 금일 소식별 알림 수를 랭킹 형태로 저장
+     * - 점수는 해당 소식의 새로 저장된 게시글 수(count)이며, 자정까지 유효한 TTL을 설정
+     *
+     * @param newsName : 소식 이름 (ZSet의 key 멤버로 사용)
+     * @param count    : 소식에 해당하는 게시글 수 (ZSet 점수로 누적됨)
+     */
+    public void incrementNewsRanking(String newsName, int count) {
+        redisRepository.incrementZSetScore(
+                RedisConstants.NEWS_RANKING_KEY_PREFIX,
+                newsName,
+                count,
+                getDurationUntilMidnight()
+        );
+    }
+
+    /**
+     * 현재 시간부터 자정까지 남은 Duration을 계산하는 유틸 메서드
+     *
+     * @return 현재 시점부터 오늘 자정까지의 Duration
+     */
+    private Duration getDurationUntilMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay();
+        return Duration.between(now, midnight);
+    }
+
+    /**
+     * Redis에 저장된 일간 소식 랭킹 정보를 조회하는 메서드
+     * - 가장 많이 등록된 소식 순서대로 상위 N개 반환
+     *
+     * @return 소식 이름과 점수를 포함한 랭킹 DTO 리스트
+     */
+    public List<NotificationRankingDto> getTopNewsRanking() {
+        return redisRepository.getTopZSetWithScore(
+                RedisConstants.NEWS_RANKING_KEY_PREFIX,
+                TOP_N,
+                NotificationRankingDto::new
+        );
+    }
+}

--- a/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
+++ b/yournews-auth/src/main/java/kr/co/yournews/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/notifies/rank").permitAll()
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .requestMatchers(ADMIN_ENDPOINTS).hasRole(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.POST, GUEST_ENDPOINTS).hasRole(Role.GUEST.name())

--- a/yournews-infra/src/main/java/kr/co/yournews/infra/redis/util/RedisConstants.java
+++ b/yournews-infra/src/main/java/kr/co/yournews/infra/redis/util/RedisConstants.java
@@ -10,6 +10,7 @@ public final class RedisConstants {
     public static final String BLACKLIST_KEY_PREFIX = "auth:blacklist::";
     public static final String PASS_KEY_PREFIX = "auth:passcode::";
     public static final String NEWS_INFO_KEY_PREFIX = "news:info::";
+    public static final String NEWS_RANKING_KEY_PREFIX = "news:ranking";
 
     public static final long DEFAULT_URL_TTL_SECONDS = 7 * 24 * 60 * 60;
     public static final long YUTOPIA_URL_TTL_SECONDS = 30 * 24 * 60 * 60;


### PR DESCRIPTION
## 배경
하루에 보낸 소식의 랭킹을 보여주는 로직이 필요

## 작업 사항
- Redis ZSet 설정 (a329cf11e85618500cb52a1902333dde7ae503d3)
- 소식 랭킹 추가 및 조회 로직 구현 (7efa325a765badf4dde8d594d843b72244c2ab73)