### PR TITLE
Feature: Async 설정

### DIFF
--- a/yournews-infra/src/main/java/kr/co/yournews/infra/config/AsyncConfig.java
+++ b/yournews-infra/src/main/java/kr/co/yournews/infra/config/AsyncConfig.java
@@ -1,9 +1,26 @@
 package kr.co.yournews.infra.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        int processors = Runtime.getRuntime().availableProcessors();    // CPU 코어 수
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(processors * 2);        // 코어 수 x 2 (IO 작업)
+        executor.setMaxPoolSize(processors * 3);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("notif-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/yournews-infra/src/main/java/kr/co/yournews/infra/mail/MailSenderAdapter.java
+++ b/yournews-infra/src/main/java/kr/co/yournews/infra/mail/MailSenderAdapter.java
@@ -26,7 +26,7 @@ public class MailSenderAdapter {
     private String mailSender;
 
     /* 메일 보내기 */
-    @Async
+    @Async(value = "notificationExecutor")
     public void sendMail(String email, String content, MailStrategy strategy) {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();


### PR DESCRIPTION
## 배경
1. `@Async`를 이용해 비동기 처리 시, 기본 설정은 `SimpleAsyncTaskExecutor` (스레드 재사용 x. 스레드 낭비 가능성 o)
그래서, `ThreadPoolTaskExecutor` 사용.
2. 기존에는 소식 전략별로 비동기 수행. 하나의 소식 전략에 90개의 소식이 있다면, 90번을 동기적으로 수행 -> 시간적 비용 증가
그래서, 전략들은 동기적으로 수행, 소식을 비동기로 처리

## 작업 사항
- ThreadPoolTaskExecutor 설정 (3c632847f13aadaae96432d8c914f5eb6b402f5a)
  - I/O Bound 작업으로 스레드 풀 사이즈를 `CPU 코어 수 * 2`로 설정
- 크롤링 ThreadPoolTaskExecutor 비동기 설정 및 News 단위 비동기 처리 변경 (10fc18b569da6f938ea32b27cd43ee49d6e141c7)
  - 전략 단위 비동기 처리 -> 소식 단위 비동기 처리