### PR TITLE
Fix: 키워드 없는 사용자에게 잘못된 알림 전송 문제 수정

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/strategy/post/DefaultPostProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/strategy/post/DefaultPostProcessor.java
@@ -25,10 +25,12 @@ public class DefaultPostProcessor extends PostProcessor {
     private final FcmTokenService fcmTokenService;
     private final DailyNotificationService dailyNotificationService;
 
-    public DefaultPostProcessor(NotificationCommandService notificationCommandService,
-                                FcmTokenService fcmTokenService,
-                                RabbitMessagePublisher rabbitMessagePublisher,
-                                DailyNotificationService dailyNotificationService) {
+    public DefaultPostProcessor(
+            NotificationCommandService notificationCommandService,
+            FcmTokenService fcmTokenService,
+            RabbitMessagePublisher rabbitMessagePublisher,
+            DailyNotificationService dailyNotificationService
+    ) {
         super(rabbitMessagePublisher);
         this.notificationCommandService = notificationCommandService;
         this.fcmTokenService = fcmTokenService;
@@ -95,7 +97,10 @@ public class DefaultPostProcessor extends PostProcessor {
      * @param strategy : 크롤링 처리 전략
      * @return : 분류된 새 게시글 정보 dto (titles, urls)
      */
-    private CrawlingPostInfo extractNewPosts(Elements elements, CrawlingStrategy strategy) {
+    private CrawlingPostInfo extractNewPosts(
+            Elements elements,
+            CrawlingStrategy strategy
+    ) {
         List<String> titles = new ArrayList<>();
         List<String> urls = new ArrayList<>();
 
@@ -124,9 +129,12 @@ public class DefaultPostProcessor extends PostProcessor {
      * @param urls     : 게시글 URL 리스트
      * @param publicId : 모든 알림에 공통으로 사용할 Public ID (묶음 식별용)
      */
-    private void saveNotifications(List<Long> userIds, String newsName,
-                                   List<String> titles, List<String> urls,
-                                   String publicId) {
+    private void saveNotifications(
+            List<Long> userIds, String newsName,
+            List<String> titles,
+            List<String> urls,
+            String publicId
+    ) {
         List<Notification> notifications = userIds.stream()
                 .map(userId -> buildNotification(newsName, titles, urls, publicId, userId))
                 .toList();


### PR DESCRIPTION
## 배경
- 키워드 파싱 후 처리 과정에서, 해당하지 않는 사용자에게도 알림을 보내는 문제 발생

## 작업 사항
 - 키워드 처리 중, 해당하는 글이 있는 사용자만 알림 시도 (062d1fe379df700297e8cc37a64e1e2e3c10f536)