### PR TITLE
Feature: 요약된 공지 조회 및 삭제 로직 구현

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/PostProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/PostProcessor.java
@@ -96,11 +96,9 @@ public abstract class PostProcessor {
         }
 
         List<NoticeSummary> summaries = new ArrayList<>();
-        List<String> urlHashes = new ArrayList<>();
 
         for (String url : urls) {
             String urlHash = HashUtil.hash(url);
-            urlHashes.add(urlHash);
 
             NoticeSummary summary = NoticeSummary.builder()
                     .url(url)
@@ -114,6 +112,6 @@ public abstract class PostProcessor {
         // 소식 요약 정보를 담기위한 데이터 저장
         noticeSummaryService.saveAll(summaries);
         // 소식 요약 진행 및 요약 정보 업데이트
-        noticeDetailCrawlingExecutor.execute(newsName, urls, urlHashes);
+        noticeDetailCrawlingExecutor.execute(newsName, urls);
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/service/NoticeDetailCrawlingExecutor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/service/NoticeDetailCrawlingExecutor.java
@@ -30,13 +30,12 @@ public class NoticeDetailCrawlingExecutor {
      *
      * @param newsName  : 뉴스/공지 출처 이름
      * @param urls      : 상세 게시글 URL 목록
-     * @param urlHashes : 각 URL의 해시 (DB 매핑 키로 사용)
      */
-    public void execute(String newsName, List<String> urls, List<String> urlHashes) {
+    public void execute(String newsName, List<String> urls) {
         IntStream.range(0, urls.size())
                 .forEach(i -> {
                     detailExecutor.execute(() -> {
-                        process(newsName, urls.get(i), urlHashes.get(i)); // URL별 트랜잭션 커밋
+                        process(newsName, urls.get(i)); // URL별 트랜잭션 커밋
                     });
                 });
     }
@@ -48,7 +47,7 @@ public class NoticeDetailCrawlingExecutor {
      * - GPT를 통한 요약 생성
      * - DB에 요약본 저장
      */
-    private void process(String newsName, String url, String urlHash) {
+    private void process(String newsName, String url) {
         log.info("[게시글 상세 크롤링 요청] newsName: {}, url: {}", newsName, url);
         Document doc = crawlingProcessor.fetch(url);
 
@@ -71,7 +70,7 @@ public class NoticeDetailCrawlingExecutor {
                 newsDetail.title(), newsDetail.content());
 
         // 요약본 저장
-        noticeSummaryCommandService.saveSummaryInfo(urlHash, summary);
+        noticeSummaryCommandService.saveSummaryInfo(url, summary);
 
         log.info("[게시글 상세 크롤링 완료] newsName: {}, url: {}", newsName, url);
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/controller/NoticeSummaryController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/controller/NoticeSummaryController.java
@@ -1,0 +1,21 @@
+package kr.co.yournews.apis.noticesummary.controller;
+
+import kr.co.yournews.apis.noticesummary.service.NoticeSummaryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/news")
+@RequiredArgsConstructor
+public class NoticeSummaryController {
+    private final NoticeSummaryQueryService noticeSummaryQueryService;
+
+    @GetMapping("/summary")
+    public ResponseEntity<?> getNoticeSummaryByUrl(@RequestParam String url) {
+        return ResponseEntity.ok(noticeSummaryQueryService.getNoticeSummaryByUrl(url));
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/dto/NoticeSummaryDto.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/dto/NoticeSummaryDto.java
@@ -1,0 +1,12 @@
+package kr.co.yournews.apis.noticesummary.dto;
+
+import kr.co.yournews.domain.notification.entity.NoticeSummary;
+
+public record NoticeSummaryDto(
+        String urlHash,
+        String summary
+) {
+    public static NoticeSummaryDto from(NoticeSummary noticeSummary) {
+        return new NoticeSummaryDto(noticeSummary.getUrlHash(), noticeSummary.getSummary());
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/service/NoticeSummaryCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/service/NoticeSummaryCommandService.java
@@ -1,9 +1,6 @@
 package kr.co.yournews.apis.noticesummary.service;
 
-import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.notification.entity.NoticeSummary;
-import kr.co.yournews.domain.notification.exception.NotificationErrorType;
-import kr.co.yournews.domain.notification.service.NoticeSummaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,18 +8,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class NoticeSummaryCommandService {
-    private final NoticeSummaryService noticeSummaryService;
+    private final NoticeSummaryQueryService noticeSummaryQueryService;
 
     /**
      * 요약된 공지 내용을 기존 데이터에 업데이트 하는 메서드
      *
-     * @param urlHash : 조회를 위한 값 (인덱스 키)
+     * @param url     : 조회를 위한 url
      * @param summary : 요약 내용
      */
     @Transactional
-    public void saveSummaryInfo(String urlHash, String summary) {
-        NoticeSummary noticeSummary = noticeSummaryService.readByUrlHash(urlHash)
-                .orElseThrow(() -> new CustomException(NotificationErrorType.SUMMARY_NOT_FOUND));
+    public void saveSummaryInfo(String url, String summary) {
+        NoticeSummary noticeSummary = noticeSummaryQueryService.getNoticeSummary(url);
 
         noticeSummary.success(summary);
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/service/NoticeSummaryQueryService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/noticesummary/service/NoticeSummaryQueryService.java
@@ -1,0 +1,38 @@
+package kr.co.yournews.apis.noticesummary.service;
+
+import kr.co.yournews.apis.noticesummary.dto.NoticeSummaryDto;
+import kr.co.yournews.common.response.exception.CustomException;
+import kr.co.yournews.common.util.HashUtil;
+import kr.co.yournews.domain.notification.entity.NoticeSummary;
+import kr.co.yournews.domain.notification.exception.NotificationErrorType;
+import kr.co.yournews.domain.notification.service.NoticeSummaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeSummaryQueryService {
+    private final NoticeSummaryService noticeSummaryService;
+
+    @Transactional(readOnly = true)
+    public NoticeSummaryDto getNoticeSummaryByUrl(String url) {
+        return NoticeSummaryDto.from(getNoticeSummary(url));
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeSummary getNoticeSummary(String url) {
+        String urlHash = HashUtil.hash(url);
+
+        // 해시 후보 중 정확히 일치하는 것 (해시 충돌을 대비해 List로 데이터 조회)
+        Optional<NoticeSummary> noticeSummary = noticeSummaryService.readAllByUrlHash(urlHash).stream()
+                .filter(ns -> url.equals(ns.getUrl()))
+                .findFirst();
+
+        // 데이터 있으면 반환, 없으면 URL로 조회
+        return noticeSummary.or(() -> noticeSummaryService.readByUrl(url))
+                .orElseThrow(() -> new CustomException(NotificationErrorType.SUMMARY_NOT_FOUND));
+    }
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationCommandService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationCommandService.java
@@ -3,6 +3,7 @@ package kr.co.yournews.apis.notification.service;
 import kr.co.yournews.common.response.exception.CustomException;
 import kr.co.yournews.domain.notification.entity.Notification;
 import kr.co.yournews.domain.notification.exception.NotificationErrorType;
+import kr.co.yournews.domain.notification.service.NoticeSummaryService;
 import kr.co.yournews.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationCommandService {
     private final NotificationService notificationService;
+    private final NoticeSummaryService noticeSummaryService;
 
     /**
      * 알림 리스트를 모두 저장하는 메서드
@@ -57,6 +59,7 @@ public class NotificationCommandService {
         log.info("[오래된 알림 삭제 요청] 기준일: {}", dateTime);
 
         notificationService.deleteByDateTime(dateTime);
+        noticeSummaryService.deleteByDateTime(dateTime);
 
         log.info("[오래된 알림 삭제 완료] 기준일 이전 데이터 삭제 완료");
     }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NoticeSummaryRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NoticeSummaryRepository.java
@@ -2,9 +2,19 @@ package kr.co.yournews.domain.notification.repository;
 
 import kr.co.yournews.domain.notification.entity.NoticeSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface NoticeSummaryRepository extends JpaRepository<NoticeSummary, Long>, CustomNoticeSummaryRepository {
-    Optional<NoticeSummary> findByUrlHash(String urlHash);
+    List<NoticeSummary> findAllByUrlHash(String urlHash);
+    Optional<NoticeSummary> findByUrl(String url);
+
+    @Modifying
+    @Query("DELETE FROM notice_summary n WHERE n.createdAt < :dateTime")
+    void deleteByDateTimeBefore(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NoticeSummaryService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NoticeSummaryService.java
@@ -5,6 +5,7 @@ import kr.co.yournews.domain.notification.repository.NoticeSummaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,7 +18,15 @@ public class NoticeSummaryService {
         noticeSummaryRepository.saveAllInBatch(noticeSummaries);
     }
 
-    public Optional<NoticeSummary> readByUrlHash(String urlHash) {
-        return noticeSummaryRepository.findByUrlHash(urlHash);
+    public List<NoticeSummary> readAllByUrlHash(String urlHash) {
+        return noticeSummaryRepository.findAllByUrlHash(urlHash);
+    }
+
+    public Optional<NoticeSummary> readByUrl(String url) {
+        return noticeSummaryRepository.findByUrl(url);
+    }
+
+    public void deleteByDateTime(LocalDateTime dateTime) {
+        noticeSummaryRepository.deleteByDateTimeBefore(dateTime);
     }
 }


### PR DESCRIPTION
## 배경
- 사용자가 요약된 로직을 조회하기 위한 로직 구현
- 현재 알림의 경우 14일 후에 자동 삭제 되므로, 요약된 내용도 14일 후에 자동 삭제 처리

## 작업 사항
- 요약 공지 조회 로직 구현 (b7c520972d8dfb73671a6e930e1511cebbd6cf42)
  -  hash 충돌 가능성을 두고, hash로 조회 후, url을 통해 동일값 조회
- 14일 지난 요약된 내용 삭제 처리 (스케줄링)