### PR TITLE
Feature: 알림 필터링 조회 로직 추가

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/controller/NotificationController.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/controller/NotificationController.java
@@ -48,13 +48,24 @@ public class NotificationController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getNotifications(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                              @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-                                              @RequestParam(required = false) Boolean isRead) {
+    public ResponseEntity<?> getNotifications(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam boolean isRead,
+            @RequestParam(required = false) String newsName,
+            @RequestParam(required = false, defaultValue = "false") boolean others
+    ) {
 
-        Page<NotificationDto.Summary> result = (isRead == null)
-                ? notificationQueryService.getNotificationsByUserId(userDetails.getUserId(), pageable)
-                : notificationQueryService.getNotificationsByUserIdAndIsRead(userDetails.getUserId(), isRead, pageable);
+        Long userId = userDetails.getUserId();
+        Page<NotificationDto.Summary> result;
+
+        if (others) {
+            result = notificationQueryService.getNotificationsByUserIdAndNewsNameNotInAndIsRead(userId, isRead, pageable);
+        } else if (newsName != null && !newsName.isBlank()) {
+            result = notificationQueryService.getNotificationsByUserIdAndNewsNameAndIsRead(userId, newsName, isRead, pageable);
+        } else {
+            result = notificationQueryService.getNotificationsByUserIdAndIsRead(userId, isRead, pageable);
+        }
 
         return ResponseEntity.ok(SuccessResponse.from(result));
     }

--- a/yournews-apis/src/test/java/kr/co/yournews/apis/notification/controller/NotificationControllerTest.java
+++ b/yournews-apis/src/test/java/kr/co/yournews/apis/notification/controller/NotificationControllerTest.java
@@ -181,35 +181,9 @@ public class NotificationControllerTest {
     class GetAllNotificationTest {
 
         @Test
-        @DisplayName("알림 목록 조회 - 전체 조회 (isRead 파라미터 없음)")
-        void getNotificationsSuccess() throws Exception {
-            // given
-            Page<NotificationDto.Summary> page = new PageImpl<>(List.of(
-                    new NotificationDto.Summary(1L, "공지", false, NotificationType.IMMEDIATE, LocalDateTime.now())
-            ));
-
-            given(notificationQueryService.getNotificationsByUserId(eq(userId), any(Pageable.class)))
-                    .willReturn(page);
-
-            // when
-            ResultActions resultActions = mockMvc.perform(
-                    get("/api/v1/notifies")
-                            .with(user(userDetails))
-            );
-
-            // then
-            resultActions
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.content[0].newsName").value("공지"))
-                    .andExpect(jsonPath("$.data.content.length()").value(1));
-        }
-
-        @Test
         @DisplayName("알림 목록 조회 - 읽음 여부 필터 (isRead=true)")
         void getNotificationsByIsReadSuccess() throws Exception {
             // given
-
             Page<NotificationDto.Summary> page = new PageImpl<>(List.of(
                     new NotificationDto.Summary(2L, "공지", true, NotificationType.IMMEDIATE, LocalDateTime.now())
             ));
@@ -221,6 +195,62 @@ public class NotificationControllerTest {
             ResultActions resultActions = mockMvc.perform(
                     get("/api/v1/notifies")
                             .param("isRead", "true")
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content[0].isRead").value(true))
+                    .andExpect(jsonPath("$.data.content.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("알림 목록 조회 - 특정 소식 필터링")
+        void getNotificationByNewsNameSuccess() throws Exception {
+            // given
+            String newsName = "특정 소식";
+            Page<NotificationDto.Summary> page = new PageImpl<>(List.of(
+                    new NotificationDto.Summary(2L, newsName, true, NotificationType.IMMEDIATE, LocalDateTime.now())
+            ));
+
+            given(notificationQueryService.getNotificationsByUserIdAndNewsNameAndIsRead(eq(userId), eq(newsName), eq(true), any(Pageable.class)))
+                    .willReturn(page);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/notifies")
+                            .param("isRead", "true")
+                            .param("newsName", newsName)
+                            .with(user(userDetails))
+            );
+
+            // then
+            resultActions
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content[0].isRead").value(true))
+                    .andExpect(jsonPath("$.data.content.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("알림 목록 조회 - 현재 구독 중이지 않는 소식 알림 조회")
+        void getNotificationByNewsNameNotInSuccess() throws Exception {
+            // given
+            String newsName = "구독 중이지 않은 소식";
+            Page<NotificationDto.Summary> page = new PageImpl<>(List.of(
+                    new NotificationDto.Summary(2L, newsName, true, NotificationType.IMMEDIATE, LocalDateTime.now())
+            ));
+
+            given(notificationQueryService.getNotificationsByUserIdAndNewsNameNotInAndIsRead(eq(userId), eq(true), any(Pageable.class)))
+                    .willReturn(page);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/notifies")
+                            .param("isRead", "true")
+                            .param("others", "true")
                             .with(user(userDetails))
             );
 

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NotificationRepository.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/repository/NotificationRepository.java
@@ -9,12 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, CustomNotificationRepository {
     Optional<Notification> findByUserIdAndPublicId(Long userId, String publicId);
-    Page<Notification> findAllByUserId(Long userId, Pageable pageable);
     Page<Notification> findAllByUserIdAndIsRead(Long userId, boolean isRead, Pageable pageable);
+    Page<Notification> findAllByUserIdAndNewsNameAndIsRead(Long userId, String newsName, boolean isRead, Pageable pageable);
+    Page<Notification> findByUserIdAndNewsNameNotInAndIsRead(Long userId, List<String> newsNames, boolean isRead, Pageable pageable);
     Long countByUserIdAndIsReadFalse(Long userId);
 
     @Modifying

--- a/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NotificationService.java
+++ b/yournews-domain/src/main/java/kr/co/yournews/domain/notification/service/NotificationService.java
@@ -28,12 +28,16 @@ public class NotificationService {
         return notificationRepository.findByUserIdAndPublicId(userId, publicId);
     }
 
-    public Page<Notification> readAllByUserId(Long userId, Pageable pageable) {
-        return notificationRepository.findAllByUserId(userId, pageable);
-    }
-
     public Page<Notification> readAllByUserIdAndIsRead(Long userId, boolean isRead, Pageable pageable) {
         return notificationRepository.findAllByUserIdAndIsRead(userId, isRead, pageable);
+    }
+
+    public Page<Notification> readAllByUserIdAndNewsNameAndIsRead(Long userId, String newsName, boolean isRead, Pageable pageable) {
+        return notificationRepository.findAllByUserIdAndNewsNameAndIsRead(userId, newsName, isRead, pageable);
+    }
+
+    public Page<Notification> readByUserIdAndNewsNameNotInAndIsRead(Long userId, List<String> newsName, boolean isRead, Pageable pageable) {
+        return notificationRepository.findByUserIdAndNewsNameNotInAndIsRead(userId, newsName, isRead, pageable);
     }
 
     public Long readUnreadCountByUserId(Long userId) {


### PR DESCRIPTION
## 배경
- 현재는 알림을 조회할 때, 구독 중인 모든 소식에 대한 알림을 모두 들고옴.
- 특정 소식에 대해 알림을 확인하기 불편함

## 작업 사항
- 알림 필터링 조회를 위한 로직 추가 (83e5fcef8c537c9423a238d2baea25804d4e9bd3)
- 알림 조회 rest api 분기별 처리 (9e4c35da7ed1176338467384180b126efe345fe7)