### PR TITLE
Refactor: 알림 데이터 저장 및 Outbox 데이터 저장 하나의 트랜잭션으로 처리

### DIFF
--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/DefaultPostProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/DefaultPostProcessor.java
@@ -5,8 +5,7 @@ import kr.co.yournews.apis.crawling.strategy.board.BoardStrategy;
 import kr.co.yournews.apis.crawling.strategy.board.YUNewsBoardStrategy;
 import kr.co.yournews.apis.crawling.strategy.dto.CrawlingPostInfo;
 import kr.co.yournews.apis.notification.service.DailyNotificationService;
-import kr.co.yournews.apis.notification.service.NotificationCommandService;
-import kr.co.yournews.apis.notification.service.NotificationOutboxEnqueueService;
+import kr.co.yournews.apis.notification.service.NotificationDispatchService;
 import kr.co.yournews.domain.notification.entity.Notification;
 import kr.co.yournews.domain.notification.service.NoticeSummaryService;
 import kr.co.yournews.domain.user.entity.FcmToken;
@@ -25,20 +24,17 @@ import java.util.stream.Collectors;
 @Slf4j
 @Component
 public class DefaultPostProcessor extends PostProcessor {
-    private final NotificationCommandService notificationCommandService;
     private final FcmTokenService fcmTokenService;
     private final DailyNotificationService dailyNotificationService;
 
     public DefaultPostProcessor(
-            NotificationCommandService notificationCommandService,
             FcmTokenService fcmTokenService,
             DailyNotificationService dailyNotificationService,
-            NotificationOutboxEnqueueService notificationOutboxService,
             NoticeSummaryService noticeSummaryService,
-            NoticeDetailCrawlingExecutor noticeDetailCrawlingExecutor
+            NoticeDetailCrawlingExecutor noticeDetailCrawlingExecutor,
+            NotificationDispatchService notificationDispatchService
     ) {
-        super(notificationOutboxService, noticeSummaryService, noticeDetailCrawlingExecutor);
-        this.notificationCommandService = notificationCommandService;
+        super(noticeSummaryService, noticeDetailCrawlingExecutor, notificationDispatchService);
         this.fcmTokenService = fcmTokenService;
         this.dailyNotificationService = dailyNotificationService;
     }
@@ -91,17 +87,13 @@ public class DefaultPostProcessor extends PostProcessor {
         // 모든 알림에 공통으로 사용될 public_id (알림 페이지 이동을 위해)
         String publicId = UUID.randomUUID().toString();
 
-        Map<Long, List<String>> userIdToTitles = userIds.stream()
-                .collect(Collectors.toMap(
-                        userId -> userId,
-                        userId -> List.copyOf(postInfo.titles())
-                ));
-
-        saveNotifications(userIds, newsName, postInfo.titles(), postInfo.urls(), publicId);
-        log.info("[알림 저장 완료] 사용자 수: {}, newsName: {}, publicId: {}", userIds.size(), newsName, publicId);
-
+        Map<Long, List<String>> userIdToTitles = buildUserIdToTitles(userIds, postInfo.titles());
+        List<Notification> notifications = buildNotifications(userIds, newsName, postInfo, publicId);
         List<FcmToken> tokens = fcmTokenService.readAllByUserIds(userIds);
-        sendFcmMessages(userIdToTitles, tokens, newsName, publicId);
+
+        dispatchNotifications(newsName, publicId, userIdToTitles, notifications, tokens);
+
+        log.info("[알림 저장 완료] 사용자 수: {}, newsName: {}, publicId: {}", userIds.size(), newsName, publicId);
     }
 
     /**
@@ -137,24 +129,39 @@ public class DefaultPostProcessor extends PostProcessor {
     }
 
     /**
+     * 사용자별 제목 매핑 생성
+     */
+    private Map<Long, List<String>> buildUserIdToTitles(List<Long> userIds, List<String> titles) {
+        return userIds.stream()
+                .collect(Collectors.toMap(
+                        userId -> userId,
+                        userId -> List.copyOf(titles)
+                ));
+    }
+
+    /**
      * 사용자별 Notification 생성 및 저장
      *
      * @param userIds  : 알림을 보낼 사용자 ID 리스트
      * @param newsName : 소식(뉴스) 이름
-     * @param titles   : 게시글 제목 리스트
-     * @param urls     : 게시글 URL 리스트
+     * @param postInfo : 게시글 정보
      * @param publicId : 모든 알림에 공통으로 사용할 Public ID (묶음 식별용)
      */
-    private void saveNotifications(
-            List<Long> userIds, String newsName,
-            List<String> titles,
-            List<String> urls,
+    private List<Notification> buildNotifications(
+            List<Long> userIds,
+            String newsName,
+            CrawlingPostInfo postInfo,
             String publicId
     ) {
-        List<Notification> notifications = userIds.stream()
-                .map(userId -> buildNotification(newsName, titles, urls, publicId, userId))
+        return userIds.stream()
+                .map(userId -> buildNotification(
+                        newsName,
+                        postInfo.titles(),
+                        postInfo.urls(),
+                        publicId,
+                        userId
+                ))
                 .toList();
-
-        notificationCommandService.createNotifications(notifications);
     }
+
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/PostProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/PostProcessor.java
@@ -2,9 +2,8 @@ package kr.co.yournews.apis.crawling.processing;
 
 import kr.co.yournews.apis.crawling.service.NoticeDetailCrawlingExecutor;
 import kr.co.yournews.apis.crawling.strategy.board.BoardStrategy;
-import kr.co.yournews.apis.notification.constant.FcmTarget;
 import kr.co.yournews.apis.notification.constant.NotificationConstant;
-import kr.co.yournews.apis.notification.service.NotificationOutboxEnqueueService;
+import kr.co.yournews.apis.notification.service.NotificationDispatchService;
 import kr.co.yournews.common.util.HashUtil;
 import kr.co.yournews.domain.notification.entity.NoticeSummary;
 import kr.co.yournews.domain.notification.entity.Notification;
@@ -24,9 +23,9 @@ import java.util.Set;
 @Slf4j
 @RequiredArgsConstructor
 public abstract class PostProcessor {
-    private final NotificationOutboxEnqueueService notificationOutboxService;
     private final NoticeSummaryService noticeSummaryService;
     private final NoticeDetailCrawlingExecutor noticeDetailCrawlingExecutor;
+    private final NotificationDispatchService notificationDispatchService;
 
     private static final Set<String> SKIP = Set.of("YuTopia(비교과)", "취업처");
 
@@ -70,20 +69,22 @@ public abstract class PostProcessor {
     }
 
     /**
-     * FCM 메시지 전송 (RabbitMQ 이용)
+     * 알림 저장 + Outbox 적재
      */
-    protected void sendFcmMessages(
-            Map<Long, List<String>> userIdToTitles,
-            List<FcmToken> tokens,
+    protected void dispatchNotifications(
             String newsName,
-            String publicId
+            String publicId,
+            Map<Long, List<String>> userIdToTitles,
+            List<Notification> notifications,
+            List<FcmToken> tokens
     ) {
         String title = NotificationConstant.getNewsNotificationTitle(newsName);
-        notificationOutboxService.enqueueMessages(
+
+        notificationDispatchService.saveNotificationsAndEnqueueOutbox(
+                notifications,
                 tokens,
                 userIdToTitles,
                 title,
-                FcmTarget.NOTIFICATION,
                 publicId
         );
     }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/YUNewsPostProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/processing/YUNewsPostProcessor.java
@@ -4,9 +4,9 @@ import kr.co.yournews.apis.crawling.service.NoticeDetailCrawlingExecutor;
 import kr.co.yournews.apis.crawling.strategy.board.BoardStrategy;
 import kr.co.yournews.apis.crawling.strategy.board.YUNewsBoardStrategy;
 import kr.co.yournews.apis.crawling.strategy.dto.CrawlingPostInfo;
+import kr.co.yournews.apis.crawling.strategy.dto.NotificationPrepareResult;
 import kr.co.yournews.apis.notification.service.DailyNotificationService;
-import kr.co.yournews.apis.notification.service.NotificationCommandService;
-import kr.co.yournews.apis.notification.service.NotificationOutboxEnqueueService;
+import kr.co.yournews.apis.notification.service.NotificationDispatchService;
 import kr.co.yournews.domain.news.dto.UserKeywordDto;
 import kr.co.yournews.domain.news.service.SubNewsService;
 import kr.co.yournews.domain.news.type.KeywordType;
@@ -29,22 +29,19 @@ import java.util.stream.Collectors;
 @Slf4j
 @Component
 public class YUNewsPostProcessor extends PostProcessor {
-    private final NotificationCommandService notificationCommandService;
     private final FcmTokenService fcmTokenService;
     private final SubNewsService subNewsService;
     private final DailyNotificationService dailyNotificationService;
 
     public YUNewsPostProcessor(
-            NotificationCommandService notificationCommandService,
             FcmTokenService fcmTokenService,
             SubNewsService subNewsService,
             DailyNotificationService dailyNotificationService,
-            NotificationOutboxEnqueueService notificationOutboxService,
             NoticeSummaryService noticeSummaryService,
-            NoticeDetailCrawlingExecutor noticeDetailCrawlingExecutor
+            NoticeDetailCrawlingExecutor noticeDetailCrawlingExecutor,
+            NotificationDispatchService notificationDispatchService
     ) {
-        super(notificationOutboxService, noticeSummaryService, noticeDetailCrawlingExecutor);
-        this.notificationCommandService = notificationCommandService;
+        super(noticeSummaryService, noticeDetailCrawlingExecutor, notificationDispatchService);
         this.fcmTokenService = fcmTokenService;
         this.subNewsService = subNewsService;
         this.dailyNotificationService = dailyNotificationService;
@@ -95,20 +92,21 @@ public class YUNewsPostProcessor extends PostProcessor {
 
         // 모든 알림에 공통으로 사용될 public_id (알림 페이지 이동을 위해)
         String publicId = UUID.randomUUID().toString();
-        Map<Long, List<String>> userIdToTitles =
-                saveNotifications(userIds, userToKeywords, keywordToPosts, newsName, publicId);
+        NotificationPrepareResult result =
+                prepareNotifications(userIds, userToKeywords, keywordToPosts, newsName, publicId);
 
-        if (userIdToTitles.isEmpty()) {
+        if (result.notifications().isEmpty()) {
             log.info("[YUNews 알림 대상 없음] newsName: {}", newsName);
             return;
         }
 
-        List<Long> notifiedUserIds = new ArrayList<>(userIdToTitles.keySet());
-        log.info("[YUNews 알림 저장 완료] 사용자 수: {}, newsName: {}, publicId: {}", notifiedUserIds.size(), newsName, publicId);
-
+        List<Long> notifiedUserIds = new ArrayList<>(result.userIdToTitles().keySet());
         List<FcmToken> tokens = fcmTokenService.readAllByUserIds(notifiedUserIds);
 
-        sendFcmMessages(userIdToTitles, tokens, newsName, publicId);
+        dispatchNotifications(newsName, publicId, result.userIdToTitles(), result.notifications(), tokens);
+
+        log.info("[YUNews 알림 저장 완료] 사용자 수: {}, newsName: {}, publicId: {}",
+                notifiedUserIds.size(), newsName, publicId);
     }
 
     /**
@@ -192,7 +190,7 @@ public class YUNewsPostProcessor extends PostProcessor {
     }
 
     /**
-     * 사용자별로 키워드 매칭된 게시글을 기반으로 Notification 생성 및 저장
+     * 사용자별 Notification 및 제목 매핑 생성
      *
      * @param userIds        : 알림을 보낼 사용자 ID 리스트
      * @param userToKeywords : 사용자별 구독 키워드 매핑
@@ -200,14 +198,13 @@ public class YUNewsPostProcessor extends PostProcessor {
      * @param newsName       : 소식(뉴스) 이름
      * @param publicId       : 모든 알림에 공통으로 사용할 Public ID (묶음 식별용)
      */
-    private Map<Long, List<String>> saveNotifications(
+    private NotificationPrepareResult prepareNotifications(
             List<Long> userIds,
             Map<Long, List<KeywordType>> userToKeywords,
             Map<KeywordType, CrawlingPostInfo> keywordToPosts,
             String newsName,
             String publicId
     ) {
-
         List<Notification> notifications = new ArrayList<>();
         Map<Long, List<String>> userIdToTitles = new HashMap<>();
 
@@ -226,16 +223,14 @@ public class YUNewsPostProcessor extends PostProcessor {
                 }
             }
 
-            if (!titles.isEmpty()) {
-                notifications.add(buildNotification(newsName, titles, urls, publicId, userId));
-                userIdToTitles.put(userId, titles);
+            if (titles.isEmpty()) {
+                continue;
             }
+
+            notifications.add(buildNotification(newsName, titles, urls, publicId, userId));
+            userIdToTitles.put(userId, titles);
         }
 
-        if (!notifications.isEmpty()) {
-            notificationCommandService.createNotifications(notifications);
-        }
-
-        return userIdToTitles;
+        return new NotificationPrepareResult(notifications, userIdToTitles);
     }
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/strategy/dto/NotificationPrepareResult.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/crawling/strategy/dto/NotificationPrepareResult.java
@@ -1,0 +1,12 @@
+package kr.co.yournews.apis.crawling.strategy.dto;
+
+import kr.co.yournews.domain.notification.entity.Notification;
+
+import java.util.List;
+import java.util.Map;
+
+public record NotificationPrepareResult(
+        List<Notification> notifications,
+        Map<Long, List<String>> userIdToTitles
+) {
+}

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/DailyNotificationProcessor.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/DailyNotificationProcessor.java
@@ -1,6 +1,5 @@
 package kr.co.yournews.apis.notification.service;
 
-import kr.co.yournews.apis.notification.constant.FcmTarget;
 import kr.co.yournews.apis.notification.constant.NotificationConstant;
 import kr.co.yournews.apis.notification.dto.DailyNewsDto;
 import kr.co.yournews.common.util.FcmMessageFormatter;
@@ -27,8 +26,7 @@ public class DailyNotificationProcessor {
     private final NewsService newsService;
     private final UserService userService;
     private final FcmTokenService fcmTokenService;
-    private final NotificationCommandService notificationCommandService;
-    private final NotificationOutboxEnqueueService notificationOutboxService;
+    private final NotificationDispatchService notificationDispatchService;
 
     /**
      * 일간 소식을 전송하는 메서드
@@ -50,49 +48,39 @@ public class DailyNotificationProcessor {
      */
     private void processNews(String newsName) {
         List<DailyNewsDto> newsListDtos = dailyNotificationService.getAllNewsInfo(newsName);
-        if (newsListDtos.isEmpty()) return;
+        if (newsListDtos.isEmpty()) {
+            return;
+        }
 
         log.info("[소식 처리 시작] 소식명: {}", newsName);
 
         String publicId = UUID.randomUUID().toString();
         List<Long> userIds = userService.readAllUserIdsByNewsNameAndDailySubStatusTrue(newsName);
-        List<FcmToken> tokens = fcmTokenService.readAllByUserIds(userIds);
-
-        List<String> titles = extractTitles(newsListDtos);
-
-        saveNotifications(userIds, newsName, newsListDtos, publicId);
-        sendFcmMessages(titles, tokens, newsName, publicId);
-
-        log.info("[소식 처리 완료] 소식명: {}, 사용자 수: {}, 토큰 수: {}", newsName, userIds.size(), tokens.size());
-    }
-
-    /**
-     * 사용자별 Notification 생성 및 저장
-     *
-     * @param userIds      : 알림을 보낼 사용자 ID 리스트
-     * @param newsName     : 소식(뉴스) 이름
-     * @param newsListDtos : 게시글 제목, url 리스트
-     * @param publicId     : 모든 알림에 공통으로 사용할 Public ID (묶음 식별용)
-     */
-    private void saveNotifications(List<Long> userIds, String newsName,
-                                   List<DailyNewsDto> newsListDtos,
-                                   String publicId) {
-        List<String> titles = new ArrayList<>();
-        List<String> urls = new ArrayList<>();
-
-        for (DailyNewsDto dto : newsListDtos) {
-            titles.add(dto.title());
-            urls.add(dto.url());
+        if (userIds.isEmpty()) {
+            return;
         }
+
+        List<FcmToken> tokens = fcmTokenService.readAllByUserIds(userIds);
+        List<String> titles = extractTitles(newsListDtos);
+        List<String> urls = extractUrls(newsListDtos);
 
         List<Notification> notifications = userIds.stream()
                 .map(userId -> buildNotification(newsName, titles, urls, publicId, userId))
                 .toList();
 
-        notificationCommandService.createNotifications(notifications);
+        String title = NotificationConstant.getDailyNewsNotificationTitle(newsName);
+        String content = FcmMessageFormatter.formatTitles(titles);
 
-        log.info("[알림 저장 완료] 소식명: {}, 사용자 수: {}, 게시글 수: {}, publicId: {}",
-                newsName, userIds.size(), titles.size(), publicId);
+        notificationDispatchService.saveNotificationsAndEnqueueOutbox(
+                notifications,
+                tokens,
+                title,
+                content,
+                publicId
+        );
+
+        log.info("[일간 알림 저장 + 아웃박스 적재 완료] 소식명: {}, 사용자 수: {}, 토큰 수: {}",
+                newsName, userIds.size(), tokens.size());
     }
 
     /**
@@ -110,14 +98,29 @@ public class DailyNotificationProcessor {
     }
 
     /**
+     * 일간 소식 중 url 추출 메서드
+     *
+     * @param newsListDtos : 일간 소식 목록 DTO
+     * @return : 일간 소식 url 추출 리스트
+     */
+    private List<String> extractUrls(List<DailyNewsDto> newsListDtos) {
+        List<String> urls = new ArrayList<>();
+        for (DailyNewsDto dto : newsListDtos) {
+            urls.add(dto.url());
+        }
+        return urls;
+    }
+
+    /**
      * Notification 엔티티 생성
      */
-    private Notification buildNotification(String newsName,
-                                           List<String> titles,
-                                           List<String> urls,
-                                           String publicId,
-                                           Long userId) {
-
+    private Notification buildNotification(
+            String newsName,
+            List<String> titles,
+            List<String> urls,
+            String publicId,
+            Long userId
+    ) {
         return Notification.builder()
                 .newsName(newsName)
                 .postTitle(titles)
@@ -128,20 +131,6 @@ public class DailyNotificationProcessor {
                 .isBookmarked(false)
                 .userId(userId)
                 .build();
-    }
-
-    /**
-     * FCM 메시지 전송 (RabbitMQ 이용)
-     */
-    private void sendFcmMessages(
-            List<String> titles,
-            List<FcmToken> tokens,
-            String newsName,
-            String publicId
-    ) {
-        String title = NotificationConstant.getDailyNewsNotificationTitle(newsName);
-        String content = FcmMessageFormatter.formatTitles(titles);
-        notificationOutboxService.enqueueMessages(tokens, title, content, FcmTarget.NOTIFICATION, publicId);
     }
 
 }

--- a/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationDispatchService.java
+++ b/yournews-apis/src/main/java/kr/co/yournews/apis/notification/service/NotificationDispatchService.java
@@ -1,0 +1,72 @@
+package kr.co.yournews.apis.notification.service;
+
+import kr.co.yournews.apis.notification.constant.FcmTarget;
+import kr.co.yournews.domain.notification.entity.Notification;
+import kr.co.yournews.domain.user.entity.FcmToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationDispatchService {
+    private final NotificationCommandService notificationCommandService;
+    private final NotificationOutboxEnqueueService notificationOutboxEnqueueService;
+
+    /**
+     * 알림 데이터 저장 및 Outbox 저장
+     * - 즉시 알림용
+     */
+    @Transactional
+    public void saveNotificationsAndEnqueueOutbox(
+            List<Notification> notifications,
+            List<FcmToken> tokens,
+            Map<Long, List<String>> userIdToTitles,
+            String title,
+            String publicId
+    ) {
+        if (notifications.isEmpty() || tokens.isEmpty()) {
+            return;
+        }
+
+        notificationCommandService.createNotifications(notifications);
+
+        notificationOutboxEnqueueService.enqueueMessages(
+                tokens,
+                userIdToTitles,
+                title,
+                FcmTarget.NOTIFICATION,
+                publicId
+        );
+    }
+
+    /**
+     * 알림 데이터 저장 및 Outbox 저장
+     * - 일간 알림용
+     */
+    @Transactional
+    public void saveNotificationsAndEnqueueOutbox(
+            List<Notification> notifications,
+            List<FcmToken> tokens,
+            String title,
+            String content,
+            String publicId
+    ) {
+        if (notifications.isEmpty() || tokens.isEmpty()) {
+            return;
+        }
+
+        notificationCommandService.createNotifications(notifications);
+
+        notificationOutboxEnqueueService.enqueueMessages(
+                tokens,
+                title,
+                content,
+                FcmTarget.NOTIFICATION,
+                publicId
+        );
+    }
+}


### PR DESCRIPTION
## 배경
- 이전 구조에서는 알림 데이터를 저장하는 로직과 Outbox 데이터 저장하는 로직이 같은 트랜잭션을 사용하지 않음.
- 데이터 저장 및 메시지 발행의 일관성을 위한 Outbox 패턴을 효과적으로 이용하기 위해 하나의 트랜잭션으로 처리할 필요 존재.

## 작업 사항
- 알림 데이터 저장 및 Outbox 저장 하나의 트랜잭션 처리 (e34ac47a738c77e62f9a9a033593d941b4e44e3c)
- 일간 및 즉시 알림 데이터 저장 및 메시지 발행 데이터 저장 하나의 로직으로 리팩토링 (323ef661443306c58c7bb06a04366c426e3968b2 || be867e87fa0ce377aaaaf2de1aeda1bf2a9297e5)